### PR TITLE
Fix search page export to new collection

### DIFF
--- a/src/js/search.js
+++ b/src/js/search.js
@@ -218,8 +218,9 @@ $(document).ready(function() {
         function newCollection() {
             window.api.ajax("POST", window.api.host + "/v1/collection/", {
                 name: $('.large-input').val()
-            }).done(cID => {
-                submitToCollection(cID)
+            }).done(res => {
+                var collectionId = res.id
+                submitToCollection(collectionId)
             })
         }
 


### PR DESCRIPTION
Fixes #40
 
Exporting to new collection didn't work due to change in response 
from backend when creating a new collection. New response is:

```json
{
    "id": 5
}
```

old was: `3`