### PR TITLE
Refactor api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.*~
 *.swp
 bin/
+.DS_Store
 node_modules/

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -119,7 +119,11 @@ $(function () {
 	    return ajax("POST", endpoint("/v1/collection/" + id + "/invite"), {
             email: email
 		});
-	}	
+	}
+
+	v1.collection.leave = function(cID) {
+		return ajax("POST", endpoint("/v1/collection/" + cID + "/leave"))
+	}
 
 	v1.collection.addEntry = function(cid, eid){
 		return ajax("POST", endpoint("/v1/collection/" + cid + "/addEntry"), { 

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -135,6 +135,10 @@ $(function () {
 		return ajax("GET", endpoint("/v1/collection/" + id + "/stats"))
 	}
 
+	v1.collection.members = function (id, q) {
+		return ajax("GET", endpoint("/v1/collection/" + id + "/members"), {q:q})
+	}
+
 	v1.collection.url = function(cID){
 		return endpoint("/v1/collection/" + cID + "/addEntry")
 	}

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -36,7 +36,8 @@ $(function () {
 	var v1 = window.api.v1 = {
 		account: {},
 		entry: {},
-		collection: {}
+		collection: {},
+		admin: {}
 	}
 
 	// Account API
@@ -142,6 +143,28 @@ $(function () {
 	v1.collection.url = function(cID){
 		return endpoint("/v1/collection/" + cID + "/addEntry")
 	}
+
+	// Admin API
+	v1.admin.acceptEntry = function (id) {
+		return ajax("POST", endpoint('/v1/admin/accept-entry'), {
+            entry : id
+        })
+	}
+
+    v1.admin.rejectEntry = function (id) {
+		return ajax("POST", endpoint('/v1/admin/reject-entry'), {
+            entry : id
+        })
+	}
+
+    v1.admin.pending = function () {
+        return ajax("GET", endpoint("/v1/admin/pending"))
+    }
+
+    //
+    v1.entry.taxonomy = function (id) {
+        return ajax("GET", endpoint(`/v1/entry/${id}/taxonomy`))
+    }
 
 	// Root API 
 	v1.getEntry = function (id){

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -1,16 +1,19 @@
 $(function () {
+
+	function ajax(method, url, data) {
+		return $.ajax(url, {
+			method: method,
+			data: data,
+			xhrFields: {
+				withCredentials: true
+			},
+			crossDomain: true
+		})
+	}
+
 	window.api = {
 		host: "https://api.serpconnect.cs.lth.se",
-		ajax: function (method, url, data) {
-			return $.ajax(url, {
-				method: method,
-				data: data,
-				xhrFields: {
-					withCredentials: true
-				},
-				crossDomain: true
-			})
-		},
+		ajax: ajax,
 		json: function (method, url, data) {
 			return $.ajax(url, {
 				method: method,
@@ -23,4 +26,122 @@ $(function () {
 			})
 		}
 	}
+
+	function endpoint(route) {
+		return window.api.host + route
+	}
+
+	//================================================================
+	// API v1
+	var v1 = window.api.v1 = {
+		account: {},
+		entry: {},
+		collection: {}
+	}
+
+	// Account API
+	v1.account.resetPassword = function (email) {
+		return ajax("POST", endpoint("/v1/account/reset-password"), {
+			email: email
+		})
+	}
+
+	// requires logged in, both passwords should be in plaintext
+	v1.account.changePassword = function (oldpw, newpw) {
+		return ajax("POST", endpoint("/v1/account/change-password"), {
+			old: oldpw,
+			new: newpw
+		})
+	}
+
+	v1.account.self = function () {
+		return ajax("GET", endpoint("/v1/account/self"))
+	}
+
+	v1.account.loggedIn = function () {
+		return ajax("GET", endpoint("/v1/account/login"))
+	}
+
+	v1.account.collections = function () {
+		return ajax("GET", endpoint("/v1/account/collections"))
+	}
+
+	v1.account.invites = function () {
+		return ajax("GET", endpoint("/v1/account/invites"))
+	}
+
+	v1.account.friends = function(email) {
+		return ajax("GET", endpoint("/v1/account/friends"), {
+			email: email
+		})
+	}
+
+	v1.account.lookup = function (email) {
+		return ajax("GET", endpoint("/v1/account/") + email)
+	}
+
+	v1.account.register = function (email, passw) {
+		return ajax("POST", endpoint("/v1/account/register"), {
+			email: email,
+			passw: passw
+		})
+	}
+
+	v1.account.delete = function () {
+		return ajax("POST", endpoint("/v1/account/delete"))
+	}
+
+	v1.account.logout = function () {
+		return ajax("POST", endpoint("/v1/account/logout"))
+	}
+
+	v1.account.login = function (email, passw) {
+		return ajax("POST", endpoint("/v1/account/login"), {
+			email: email,
+			passw: passw
+		})
+	}
+
+	v1.account.confirmNewPassword = function(passw){
+		return ajax("POST", endpoint("/v1/account/reset-password-confirm"), {
+			passw: passw
+		})
+	}
+
+	// Collection API
+	v1.collection.create = function (name) {
+        return ajax("POST", endpoint("/v1/collection/"), {
+            name: name
+		});
+	}
+
+	v1.collection.invite = function(email, id){
+	    return ajax("POST", endpoint("/v1/collection/" + id + "/invite"), {
+            email: email
+		});
+	}	
+
+	v1.collection.addEntry = function(cid, eid){
+		return ajax("POST", endpoint("/v1/collection/" + cid + "/addEntry"), { 
+			entryId: eid 
+		})
+	}
+	
+	v1.collection.stats = function(id){
+		return ajax("GET", endpoint("/v1/collection/" + id + "/stats"))
+	}
+
+	v1.collection.url = function(cID){
+		return endpoint("/v1/collection/" + cID + "/addEntry")
+	}
+
+	// Root API 
+	v1.getEntry = function (id){
+		return ajax("GET", endpoint("/v1/entry/") + id)
+	}
+
+	v1.getTaxonomyEntry = function (id){
+		return ajax("GET", endpoint("/v1/entry/" + id + "/taxonomy"))
+	}
+	
 })

--- a/src/js/central.js
+++ b/src/js/central.js
@@ -32,7 +32,6 @@ $(document).ready(function() {
         "other": "Other"
     }
 
-
 	central.constructEntities= function(taxonomy, facet) {
 		var filtered = taxonomy[facet] || []
 
@@ -64,4 +63,5 @@ $(document).ready(function() {
 			samples.map(facet => central.constructSubfacet(taxonomy, facet))
 		])
 	}
+
 })

--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -15,7 +15,7 @@ $(function () {
 
 	['general', 'users', 'entries'].forEach(id => updateLink(document.getElementById(id)))
 
-	window.user.collections()
+	window.api.v1.account.collections()
 		.done(collections => collections.forEach(collection => {
 			if (collection.id === Number(cID))
 				setupName(collection)

--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -6,7 +6,7 @@ $(function () {
 	if (window.location.hash.length === 0)
 		toProfilePage()
 
-	// http://serpconnect.cs.lth.se/collection.html#33
+	// http://serpconnect.cs.lth.se/collection.html#33 => 33
 	var cID = window.location.hash.substring(1)
 
 	function updateLink(el) {
@@ -22,31 +22,40 @@ $(function () {
 		}))
 		.fail(toProfilePage)
 
-	window.api.ajax("GET", window.api.host + "/v1/collection/" + cID + "/stats")
+	window.api.v1.collection.stats(cID)
 		.done(setupStats)
 		.fail(toProfilePage)
 
 	function setupName(collection) {
-		var elName = $('#name').text(collection.name)
-		var elID = $('#id').text(collection.id)
+		$('#name').text(collection.name)
+		$('#id').text(collection.id)
 	}
 
+	/* X member(s), Y entr(y|ies) */
+    function formatStats(members, entries) {
+        var mems = members === 1 ? "member" : "members"
+        var entr = entries === 1 ? "entry" : "entries"
+
+        return `${members} ${mems}, ${entries} ${entr}`
+    }
+
 	function setupStats(stats) {
-		var elStats = $('.collection-stats').text(
-			`${stats.members} user${stats.members > 1 ? 's' : ''}, ${stats.entries} entr${stats.entries > 1 ? 'ies' : 'y'}`)
+		$('.collection-stats').text(formatStats(stats.members, stats.entries))
 	}
 
 	function leave() {
         var confirm = el('button.btn', ['leave'])
         var cancel = el('button.btn', ['cancel'])
 
-        var modal = el('div.modal', [el('div', [
-            el("div.modal-header-title", [$('#name').text()]),
-            el("div.modal-divider"),
-            el("div.modal-sub-item", ['Leave collection?']),
-            el("div.modal-divider"),
-            confirm, cancel
-        ])])
+        var modal = el('div.modal', [
+			el('div', [
+				el("div.modal-header-title", [$('#name').text()]),
+				el("div.modal-divider"),
+				el("div.modal-sub-item", ['Leave collection?']),
+				el("div.modal-divider"),
+				confirm, cancel
+        	])
+		])
 
         cancel.addEventListener('click', (evt) => {
             document.body.removeChild(modal)
@@ -57,12 +66,11 @@ $(function () {
             cancel.classList.add('submit-disabled')
             confirm.setAttribute('disabled', true)
             cancel.setAttribute('disabled', true)
-            window.api.ajax("POST", window.api.host + "/v1/collection/" + cID + "/leave")
-            	.always(toProfilePage)
+            window.api.v1.collection.leave(cID).always(toProfilePage)
         })
 
         document.body.appendChild(modal)
     }
 
-	document.getElementById('logout').addEventListener('click', leave, false)
+	document.getElementById('leave').addEventListener('click', leave, false)
 })

--- a/src/js/collection/entries.js
+++ b/src/js/collection/entries.js
@@ -71,81 +71,26 @@ $(function () {
 	function inspectEntry(evt) {
 		var id = this.dataset.entryId
 
+		function removeFromCollection() {
+            toggleButtonState()
+			window.api.ajax("POST", window.api.host + "/v1/collection/" + cID + "/removeEntry", {
+				entryId: id
+			})
+				.done(() => {
+					document.body.removeChild(modal)
+					refresh()
+				})
+				.fail(xhr => alert(xhr.responseText))
+		}
+
+        var removeBtn = el("button.btn", ["remove from collection"])
+        removeBtn.addEventListener('click', removeFromCollection, false)
+
 		window.api.ajax("GET", window.api.host + "/v1/entry/" + id).done(entry => {
 			window.api.ajax("GET", window.api.host + "/v1/entry/" + id + "/taxonomy").done(taxonomy => {
-				var close = el('div.close-btn')
-
-				close.addEventListener('click', function (evt) {
-					document.body.removeChild(close.parentNode.parentNode)
-				}, false)
-
-				var constructFacet = function(name) {
-					var samples = Object.keys(taxonomy).filter(
-						facet => reverseMap[facet.toLowerCase()] === name
-					) || []
-
-					if (!samples.length) return undefined
-
-					return el("div.modal-header-title", [
-						name,
-						samples.map(facet => {
-							var filtered = taxonomy[facet] || []
-							return el('div.modal-sub-sub-item', [
-								shorthandMap[facet.toLowerCase()],
-								filtered.map(sample => (sample === "unspecified"
-									? undefined : el('div.modal-sub-sub-item', [sample])))
-							])
-						})
-					])
-				}
-
-				var extraInfo = []
-				if (entry.type === "challenge") {
-					extraInfo.push(
-						el('div.modal-header-title', ['Description']),
-						el('div.modal-sub-item', [entry.description]))
-				} else {
-					extraInfo.push(
-						el('div.modal-header-title', ['References']),
-						el('div.modal-sub-item', [entry.reference]),
-						el('div.modal-header-title', ['DOI']),
-						el('div.modal-sub-item', [entry.doi]))
-				}
-
-				var editBtn = el('button.edit-btn', ['edit'])
-				var removeBtn = el('button.edit-btn', ['remove from collection'])
-
-				editBtn.addEventListener('click', () => {
-					toggleButtonState()
-					window.location = "/submit.html?e=" + id
-				}, false)
-
-				removeBtn.addEventListener('click', () => {
-					toggleButtonState()
-					window.api.ajax("POST", window.api.host + "/v1/collection/" + cID + "/removeEntry", {
-			    		entryId: id
-			    	})
-			    		.done(() => {
-			    			document.body.removeChild(modal)
-			    			refresh()
-			    		})
-			    		.fail(xhr => window.alert(JSON.stringify(xhr)))
-    			}, false)
-
-				var modal = el('div.modal', [el('div', [
-					close, el("div.modal-entry-type", [entry.type]),
-					el("div.modal-header-title", [`entry #${entry.id}`]),
-					el("div.modal-divider"),
-					constructFacet("Effect"),
-					constructFacet("Scope"),
-					constructFacet("Context"),
-					el("div.modal-divider"),
-					extraInfo,
-					el("div.modal-divider"),
-					removeBtn, editBtn
-				])])
-
-				document.body.appendChild(modal)
+				modals.entryModal(entry, taxonomy, {
+                    button: [removeBtn]
+				})
 			})
 		})
 	}

--- a/src/js/collection/users.js
+++ b/src/js/collection/users.js
@@ -15,8 +15,8 @@ $(function () {
 	['general', 'users', 'entries'].forEach(id => updateLink(document.getElementById(id)))
 
 	function refresh(){
-		window.api.ajax("GET", window.api.host + "/v1/collection/" + cID + "/members")
-			.done(setupMembers)
+		api.v1.collection.members(cID, "all")
+            .done(setupMembers)
 			.fail(toProfilePage)
 	}
 
@@ -35,77 +35,22 @@ $(function () {
 			}))
 	}
 
-	function invite(evt) {
-        var send = el('button.btn', ['send'])
-        var cancel = el('button.btn', ['cancel'])
-        var modal = el('div.modal', [el('div', [
-            el("div.modal-header-title", ["send invite"]),
-            el("div.modal-divider"),
-            el('input#email.submit-input-box', {
-                placeholder : 'user email',
-                type : 'email',
-                name : 'email'
-            }),
-            el("div.modal-divider"),
-            send, cancel
-        ])])
+    var inviteModal = {
+        desc: "Invite user",
+        message: "",
+        input: [["input0", "email", "user@email.com"]],
+        btnText: "invite"
+    }
 
-        cancel.addEventListener('click', (evt) => {
-            document.body.removeChild(modal)
-        }, false)
-
-        send.addEventListener('click', (evt) => {
-            toggleButtonState()
-
-            window.api.ajax("POST", window.api.host + "/v1/collection/" + cID + "/invite", {
-                email: $('#email').val(),
-            })
+    $('#invite').click(evt => {
+        modals.optionsModal(inviteModal, function (email) {
+            api.v1.collection.invite(email, cID)
                 .done(ok => {
-                    document.body.removeChild(modal)
+                    modals.clearAll()
                     refresh()
                 })
-                .fail(xhr => {
-                    $('.complaint').remove()
-                    var div = document.getElementById('name')
-                    div.parentNode.insertBefore(el('div.complaint', [
-                        xhr.responseText
-                    ]), div.nextSibling)
-                    toggleButtonState()
-                })
-        }, false)
-
-        document.body.appendChild(modal)
-        modal.querySelector('input').focus()
-    }
-
-    // Switch all buttons between disabled and enabled state
-    function toggleButtonState() {
-        var btns = document.querySelectorAll('.btn')
-        for (var i = 0; i < btns.length; i++) {
-            btns[i].classList.toggle('submit-disabled')
-            if (btns[i].getAttribute('disabled'))
-                btns[i].removeAttribute('disabled')
-            else
-                btns[i].setAttribute('disabled', true)
-
-        }
-    }
-
-    document.addEventListener('keydown', function (evt) {
-        if (evt.keyCode === 27) {
-            var modal = document.querySelector('.modal')
-            if (!modal) return
-            document.body.removeChild(modal)
-        }
+                .fail(xhr => alert(xhr.responseText))
+        })
     })
-
-    window.addEventListener('load', () => {
-        document.body.addEventListener('click', function (evt) {
-            if (evt.target.className === "modal")
-                document.body.removeChild(evt.target)
-        }, false)
-    })
-
-    $('#logout').click(invite)
 
 })

--- a/src/js/entries.js
+++ b/src/js/entries.js
@@ -9,7 +9,7 @@ $(document).ready(function() {
             api.v1.entry.taxonomy(entry.id).done(taxonomy => {
                 entries.push(entry)
                 entry.serpClassification = taxonomy
-                insertIntoTable(entry)
+                insertIntoTable(entry, entries.length - 1)
             })
         })
     }).fail(xhr => {
@@ -35,106 +35,103 @@ $(document).ready(function() {
             .fail(xhr => window.alert(xhr.responseText))
     }
     
-    function createCell(subfacet, alternating) {
-        return el(`td${classification[subfacet.toUpperCase()] ? '.filled-cell' : ''}${alternating ? '.alternating-group' : ''}`)
+    function createCell(taxonomy, subfacet, alternating) {
+        var filled = taxonomy[subfacet.toUpperCase()] ? '.filled-cell' : ''
+        var alt = alternating ? '.alternating-group' : ''
+        return el(`td${filled}${alt}`)
     }
 
-    function insertIntoTable(entry, position) {
-        var classification = entry.serpClassification
+    function acceptEntryCallback(evt) {
+        commit(Number(this.dataset.entryNumber), acceptEntry)
+    }
+
+    function rejectEntryCallback(evt) {
+        commit(Number(this.dataset.entryNumber), rejectEntry)
+    }
+
+    function entryButton(name, style, entryNumber, fn) {
+        var btn = el(`button.${style}`, {
+            'data-entry-number': entryNumber
+        }, [name]);
+        btn.addEventListener("click", fn, false);
+        return btn;
+    }
+
+    var maxLength = 35;
+    function insertIntoTable(entry, entryNumber) {
+        var entryTitle = entry["description"] || entry["reference"];
+        if (entryTitle.length > maxLength)
+            entryTitle = entryTitle.substring(0, maxLength - 3) + "..." 
+
+        var title = el('td', [entryTitle])
+        title.addEventListener('click', buildModalView, false)
 
         // let's build the table row for this entry
-        var maxLength = 35;
-        var entryTitle = entry["description"] || entry["reference"];
-        entryTitle = entryTitle.length > maxLength ?
-            entryTitle.substring(0, maxLength - 3) + "..." :
-            entryTitle.substring(0, maxLength);
+        var row = el('tr', {'data-entry-number': entryNumber }, [
+            title,
 
-        var acceptBtn = el("button.entries-accept-btn", ["accept"]);
-        acceptBtn.addEventListener("click", function(evt) {
-            var entryNumber = this.parentNode.children[0].dataset.entryNumber
-            commit(entryNumber, acceptEntry)
-        }, false);
-
-        var rejectBtn = el("button.entries-reject-btn", ["reject"]);
-        rejectBtn.addEventListener("click", function(evt) {
-            var entryNumber = this.parentNode.children[0].dataset.entryNumber
-            commit(entryNumber, rejectEntry)
-        }, false);
-
-        var row = el('tr', [
-            el('td', {'data-entry-number': entries.indexOf(entry) }, [entryTitle]),
-
-            createCell("intervention", true),
+            createCell(entry.serpClassification, "intervention", true),
 
             // effect
-            createCell("solving"),
-            createCell("adapting"),
-            createCell("assessing"),
-            createCell("improving"),
+            createCell(entry.serpClassification, "solving"),
+            createCell(entry.serpClassification, "adapting"),
+            createCell(entry.serpClassification, "assessing"),
+            createCell(entry.serpClassification, "improving"),
 
             // scope
-            createCell("planning", true),
-            createCell("design", true),
-            createCell("execution", true),
-            createCell("analysis", true),
+            createCell(entry.serpClassification, "planning", true),
+            createCell(entry.serpClassification, "design", true),
+            createCell(entry.serpClassification, "execution", true),
+            createCell(entry.serpClassification, "analysis", true),
 
             // context
-            createCell("people"),
-            createCell("information"),
-            createCell("sut"),
-            createCell("other"),
+            createCell(entry.serpClassification, "people"),
+            createCell(entry.serpClassification, "information"),
+            createCell(entry.serpClassification, "sut"),
+            createCell(entry.serpClassification, "other"),
 
-            acceptBtn,
-            rejectBtn
+            el('td', [entryButton('accept', 'entries-accept-btn', entryNumber, acceptEntryCallback)]),
+            el('td', [entryButton('reject', 'entries-reject-btn', entryNumber, rejectEntryCallback)])
         ])
 
         document.getElementById("table-body").appendChild(row);
-
-        $("td:first-child").on("click", function(evt) {
-            var entryNumber = $(this).data("entry-number");
-            var entry = entries[entryNumber];
-            buildModalView(entry, entryNumber);
-        });
     }
 
-    // convenience function for capitalizing sentences
-    String.prototype.capitalize = function() {
-        return this.charAt(0).toUpperCase() + this.slice(1);
-    }
-
-    function buildModalView(entry, entryNumber) {
-        var acceptBtn = el("button.btn", ["accept"]);
-        acceptBtn.addEventListener("click", function(evt) {
-            commit(entryNumber, acceptEntry)
-        }, false);
-
-        var rejectBtn = el("button.btn", ["reject"]);
-        rejectBtn.addEventListener("click", function(evt) {
-            commit(entryNumber, rejectEntry)
-        }, false);
+    function buildModalView(evt) {
+        var entryNumber = Number(this.parentNode.dataset.entryNumber);
+        var entry = entries[entryNumber];
 
         var modalOpt = {
-            button: [acceptBtn, rejectBtn]
+            button: [
+                entryButton('accept', 'btn', entryNumber, acceptEntryCallback),
+                entryButton('reject', 'btn', entryNumber, rejectEntryCallback)
+            ]
         }
 
         modals.entryModal(entry, entry.serpClassification, modalOpt)
     }
 
     function removeEntry(entryNumber) {
-        var num = Number(entryNumber)
-        
-        // remove the entry from the table
-        $("#table-body tr:nth-child(" + (num + 1) + ")").remove();
-
-        // remove from our internal array
-        entries.splice(num, 1);
+        var table = document.getElementById("table-body")
 
         // update data attribute of the table cells after the removed entry
-        var cells = document.querySelectorAll("td:first-child")
-        for (var i = num; i < cells.length; i++) {
-            console.log(i, cells[i], cells[i].dataset)
-            cells[i].dataset.entryNumber = cells[i].dataset.entryNumber - 1
+        for (var i = entryNumber + 1; i < table.children.length; i++) {
+            var row = table.children[i]
+            var num = Number(row.dataset.entryNumber) - 1
+
+            row.dataset.entryNumber = num
+
+            var btns = row.querySelectorAll('button')
+            for (var j = 0; j < btns.length; j++)
+                btns[i].dataset.entryNumber = num
         }
+
+        // remove the entry from the table, entryNumber+1 since nth-child starts from 1
+        var row = table.children[entryNumber]
+        row.parentNode.removeChild(row)
+
+        // remove from our internal array
+        entries.splice(entryNumber, 1);        
     }
 
 });

--- a/src/js/entries.js
+++ b/src/js/entries.js
@@ -8,7 +8,7 @@ $(document).ready(function() {
         pending.forEach(entry => {
             api.v1.entry.taxonomy(entry.id).done(taxonomy => {
                 entries.push(entry)
-                entry.serpClassification = taxonomy
+                entry.taxonomy = taxonomy
                 insertIntoTable(entry, entries.length - 1)
             })
         })
@@ -34,12 +34,6 @@ $(document).ready(function() {
             })
             .fail(xhr => window.alert(xhr.responseText))
     }
-    
-    function createCell(taxonomy, subfacet, alternating) {
-        var filled = taxonomy[subfacet.toUpperCase()] ? '.filled-cell' : ''
-        var alt = alternating ? '.alternating-group' : ''
-        return el(`td${filled}${alt}`)
-    }
 
     function acceptEntryCallback(evt) {
         commit(Number(this.dataset.entryNumber), acceptEntry)
@@ -53,8 +47,19 @@ $(document).ready(function() {
         var btn = el(`button.${style}`, {
             'data-entry-number': entryNumber
         }, [name]);
-        btn.addEventListener("click", fn, false);
+
+        if (name === 'accept')
+            btn.addEventListener("click", acceptEntryCallback, false);
+        else
+            btn.addEventListener("click", rejectEntryCallback, false);
+
         return btn;
+    }
+    
+    function createCell(taxonomy, subfacet, alternating) {
+        var filled = taxonomy[subfacet.toUpperCase()] ? '.filled-cell' : ''
+        var alt = alternating ? '.alternating-group' : ''
+        return el(`td${filled}${alt}`)
     }
 
     var maxLength = 35;
@@ -70,28 +75,28 @@ $(document).ready(function() {
         var row = el('tr', {'data-entry-number': entryNumber }, [
             title,
 
-            createCell(entry.serpClassification, "intervention", true),
+            createCell(entry.taxonomy, "intervention", true),
 
             // effect
-            createCell(entry.serpClassification, "solving"),
-            createCell(entry.serpClassification, "adapting"),
-            createCell(entry.serpClassification, "assessing"),
-            createCell(entry.serpClassification, "improving"),
+            createCell(entry.taxonomy, "solving"),
+            createCell(entry.taxonomy, "adapting"),
+            createCell(entry.taxonomy, "assessing"),
+            createCell(entry.taxonomy, "improving"),
 
             // scope
-            createCell(entry.serpClassification, "planning", true),
-            createCell(entry.serpClassification, "design", true),
-            createCell(entry.serpClassification, "execution", true),
-            createCell(entry.serpClassification, "analysis", true),
+            createCell(entry.taxonomy, "planning", true),
+            createCell(entry.taxonomy, "design", true),
+            createCell(entry.taxonomy, "execution", true),
+            createCell(entry.taxonomy, "analysis", true),
 
             // context
-            createCell(entry.serpClassification, "people"),
-            createCell(entry.serpClassification, "information"),
-            createCell(entry.serpClassification, "sut"),
-            createCell(entry.serpClassification, "other"),
+            createCell(entry.taxonomy, "people"),
+            createCell(entry.taxonomy, "information"),
+            createCell(entry.taxonomy, "sut"),
+            createCell(entry.taxonomy, "other"),
 
-            el('td', [entryButton('accept', 'entries-accept-btn', entryNumber, acceptEntryCallback)]),
-            el('td', [entryButton('reject', 'entries-reject-btn', entryNumber, rejectEntryCallback)])
+            el('td', [entryButton('accept', 'entries-accept-btn', entryNumber)]),
+            el('td', [entryButton('reject', 'entries-reject-btn', entryNumber)])
         ])
 
         document.getElementById("table-body").appendChild(row);
@@ -103,35 +108,33 @@ $(document).ready(function() {
 
         var modalOpt = {
             button: [
-                entryButton('accept', 'btn', entryNumber, acceptEntryCallback),
-                entryButton('reject', 'btn', entryNumber, rejectEntryCallback)
+                entryButton('accept', 'btn', entryNumber),
+                entryButton('reject', 'btn', entryNumber)
             ]
         }
 
-        modals.entryModal(entry, entry.serpClassification, modalOpt)
+        modals.entryModal(entry, entry.taxonomy, modalOpt)
     }
 
     function removeEntry(entryNumber) {
         var table = document.getElementById("table-body")
 
-        // update data attribute of the table cells after the removed entry
+        entries.splice(entryNumber, 1); 
+
+        // Update data attribute of the table cells _after_ the entry
         for (var i = entryNumber + 1; i < table.children.length; i++) {
             var row = table.children[i]
             var num = Number(row.dataset.entryNumber) - 1
 
-            row.dataset.entryNumber = num
-
             var btns = row.querySelectorAll('button')
             for (var j = 0; j < btns.length; j++)
                 btns[i].dataset.entryNumber = num
+                
+            row.dataset.entryNumber = num
         }
 
-        // remove the entry from the table, entryNumber+1 since nth-child starts from 1
-        var row = table.children[entryNumber]
-        row.parentNode.removeChild(row)
-
-        // remove from our internal array
-        entries.splice(entryNumber, 1);        
+        // Remove after loop to reduce jank
+        table.removeChild(table.children[entryNumber])
     }
 
 });

--- a/src/js/modal.js
+++ b/src/js/modal.js
@@ -135,9 +135,20 @@ $(document).ready(function() {
 		}, modalAnimation)
 	 }
 
-	/* Create a modal that displays contents of an entry & an edit button */
-	modals.entryModal = function(entry, taxonomy) {
+	/** 
+	 * Create a modal that displays contents of an entry & an edit button.
+	 * 
+	 * @param {object} entry 	straight from the API
+	 * @param {object} taxonomy also straight from the API
+	 * @param {object} options 	configure some stuff
+	 * 
+	 * options.button = [buttonEl, ..., buttonEl]
+	 *     - button elements are added after the edit button
+	 * */
+	modals.entryModal = function(entry, taxonomy, options) {
        	var editBtn = el('button#editBtn.edit-btn', ['edit'])
+		var extraButtons = (options && options.button) || []
+
 		var modal = el('div#modal.modal', [
 			el('div',[
 				el('div.modal-entry-type', [entry.type]),
@@ -160,12 +171,12 @@ $(document).ready(function() {
 					el('div.modal-sub-item', [entry.doi]),
 					el("div.modal-divider")
 				],
-				editBtn
+				editBtn, 
+				extraButtons
 			])	
 		])
 
 		editBtn.addEventListener("click", function(evt) {
-            $(".modal").remove();
             window.location = `/submit.html?e=${entry.id}`;
         });
 	    

--- a/src/js/modal.js
+++ b/src/js/modal.js
@@ -1,5 +1,16 @@
 $(document).ready(function() {
 
+	function toggleButtonState() {
+        var btns = document.querySelectorAll('.btn')
+        for (var i = 0; i < btns.length; i++) {
+            btns[i].classList.toggle('submit-disabled')
+            if (btns[i].getAttribute('disabled'))
+                btns[i].removeAttribute('disabled')
+            else
+                btns[i].setAttribute('disabled', true)
+        }
+    }
+
 	var modals = window.modals = {}
 	var modalAnimation = 121
 
@@ -247,6 +258,16 @@ $(document).ready(function() {
             inputboxes[0].focus()
         }
     }
+
+	modals.clearAll = function() {
+		var modal = document.querySelector('.modal')
+		if (modal)
+			modal.parentNode.removeChild(modal)
+
+		var confirm = document.querySelector('.confirm')
+		if (confirm)
+			confirm.parentNode.removeChild(confirm)
+	}
 })
 
 // Remove active modal when clicking outside modal
@@ -262,14 +283,8 @@ window.addEventListener('load', () => {
 	document.addEventListener('keydown', (evt) => {
 		if (evt.keyCode !== 27)
 			return
-
-		var modal = document.querySelector('.modal')
-		if (modal)
-			modal.parentNode.removeChild(modal)
-
-		var confirm = document.querySelector('.confirm')
-		if (confirm)
-			confirm.parentNode.removeChild(confirm)
+		
+		window.modals.clearAll()
 	}, false)
 }, false)
 

--- a/src/js/search.js
+++ b/src/js/search.js
@@ -174,7 +174,7 @@ $(document).ready(function() {
     }
 
     function exportEntries(){
-        if (selectedEntries.length) {
+        if (!selectedEntries.length) {
             return
         }
 

--- a/src/js/submit.js
+++ b/src/js/submit.js
@@ -459,33 +459,29 @@ $(document).ready(function() {
         submit()
     });
 
+    var newCollectionModal = {  
+        desc: "create new collection",
+        message: "",
+        input: [['input0','text','collection name']],
+        btnText: "Create"
+    };
+
     $("#submit-create-collection").on("click", function(evt) {
-        var create = new window.modal(
-		    el('div.modal-header-title', ['create collection']),
-            el('input.submit-input-box', {placeholder: 'my best entries'}, [])
-        );
-        
-        create.
-		    confirm('create', (evt) => {
-			    create.toggleButtonState()	
-
-                window.api.ajax("POST", window.api.host + "/v1/collection/", {
-                    name: create.div.querySelector('input').value
+        modals.optionsModal(newCollectionModal, function (name) {
+            api.v1.collection.create(name)
+                .done(ok => {
+                    document.body.removeChild(this.modal)
+                    querystring.c = ok.id
+                    updateCollectionList()
                 })
-                    .done(ok => {
-                        document.body.removeChild(create.div)
-
-                        // Use internal qs to avoid messing up user
-                        querystring.c = ok.id
-                        updateCollectionList()
-                    })
-                    .fail(xhr => {
-                        window.alert(xhr.responseText)
-                        modal.toggleButtonState()
-                    })
-            }).
-            cancel('cancel').
-            show();
+                .fail(xhr => {
+                    $('.modal-complaint').remove()
+                    var modal = document.querySelector(".modal") || document.querySelector(".confirm")
+                    var error = modal.querySelector('#input0')
+                    var complaint = el('div.modal-complaint', [xhr.responseText])
+                    error.parentNode.insertBefore(complaint, error.nextSibling)
+                })
+        })
     });
 
     $("#submit-btn").on("click", function(evt) {

--- a/src/js/user.js
+++ b/src/js/user.js
@@ -2,107 +2,43 @@ $(function (){
 
 	var user = window.user = {}
 
-	user.resetPassword = function (email) {
-		return window.api.ajax("POST", window.api.host + "/v1/account/reset-password", {
-			email: email
-		})
+    user.resetPassword = window.api.v1.account.resetPassword
+    user.changePassword = window.api.v1.account.changePassword
+    user.self = window.api.v1.account.self
+    user.collections = window.api.v1.account.collections
+    user.createCollection = window.api.v1.collection.create
+    user.collectionInvite = window.api.v1.collection.invite
+
+	user.putIntoCollection = function(url, eID){
+		return window.api.ajax("POST", url, { entryId: eID })
 	}
 
-	// requires logged in, both passwords should be in plaintext
-	user.changePassword = function (oldpw, newpw) {
-		return window.api.ajax("POST", window.api.host + "/v1/account/change-password", {
-			old: oldpw,
-			new: newpw
-		})
-	}
-
-	user.self = function () {
-		return window.api.ajax("GET", window.api.host + "/v1/account/self")
-	}
-
-	user.collections = function () {
-		return window.api.ajax("GET", window.api.host + "/v1/account/collections")
-	}
-
-	user.createCollection = function (name) {
-		 return window.api.ajax("POST", window.api.host + "/v1/collection/", {
-		 	name: name
-		 });
-	}
-
-	user.collectionInvite = function(email,id){
-		return window.api.ajax("POST", window.api.host + "/v1/collection/" + id + "/invite", {
-                email: email
-            });
-	}	
-
-	user.putIntoCollection = function(url,eID){
-		return window.api.ajax("POST", url, {entryId: eID })
-	}
-
-	user.collectionUrl = function(cID){
-		return window.api.host + "/v1/collection/" + cID + "/addEntry"
-	}
-
-	user.invites = function () {
-		return window.api.ajax("GET", window.api.host + "/v1/account/invites")
-	}
-
-	user.lookup = function (email) {
-		return window.api.ajax("GET", window.api.host + "/v1/account/" + email)
-	}
-
-	user.register = function (email, passw) {
-		return window.api.ajax("POST", window.api.host + "/v1/account/register", {
-			email: email,
-			passw: passw
-		})
-	}
-
-	user.delete = function () {
-		return window.api.ajax("POST", window.api.host + "/v1/account/delete")
-	}
-
-	//
-	user.logout = function () {
-		return window.api.ajax("POST", window.api.host + "/v1/account/logout")
-	}
-
-	// .done(() => {}), .fail(xhr => console.log(xhr.responseText))
-	user.login = function (email, passw) {
-		return window.api.ajax("POST", window.api.host + "/v1/account/login", {
-			email: email,
-			passw: passw
-		})
-	}
+	user.collectionUrl = window.api.v1.collection.url
+	user.invites = window.api.v1.account.invites
+	user.friends = window.api.v1.account.friends
+	user.lookup = window.api.v1.account.lookup
+	user.register = window.api.v1.account.register
+	user.delete = window.api.v1.account.delete
+	user.logout = window.api.v1.account.logout
+	user.login = window.api.v1.account.login
+	user.resetpassword = window.api.v1.account.confirmNewPassword
+	user.getEntry = window.api.v1.getEntry
+	user.getTaxonomyEntry = window.api.v1.getTaxonomyEntry
 
 	// Logout user when logout button is clicked
-    $("#logout").click(evt => window.user.logout().done(toHome))
-
-    //logout to home page
-    function toHome() {
-    	window.location = "/"
+    function logout() {
+        api.v1.account.logout().done(ok => window.location = "/")
     }
 
-	user.resetpassword = function(passw){
-		return window.api.ajax("POST", window.api.host + "/v1/account/reset-password-confirm", {
-			passw: passw
-		})
-	}
+    $("#logout").click(logout)
 
-	user.getEntry = function (id){
-		return window.api.ajax("GET", window.api.host + "/v1/entry/" + id)
-	}		
-	user.getTaxonomyEntry = function (id){
-		return window.api.ajax("GET", window.api.host + "/v1/entry/" + id + "/taxonomy")
-	}
+
+    function loggedIn() {
+        $("#logout").text("logout").attr("href", "/")
+        $("#profile").text("profile").attr("href", "/profile.html")
+    }
 
 	// TODO: Get a somewhat better solution that doesn't flicker
 	//#logout is the id for both login/signup + logout
-	window.api.ajax("GET", window.api.host + "/v1/account/login")
-	.done(() => $("#logout").text("logout").attr("href", "/"))
-
-	window.api.ajax("GET", window.api.host + "/v1/account/login")
-	.done(() => $("#profile").text("profile").attr("href", "/profile.html"))
-
+	api.v1.account.loggedIn().done(loggedIn)
 })

--- a/src/less/workingfiles/entries.less
+++ b/src/less/workingfiles/entries.less
@@ -1,52 +1,53 @@
-
 #entries-table {
     #queue-table();
+    background-color: white;
+
+    & th {
+        border: none;
+    }
+
+    & td {
+        text-align: center;
+        border: none;
+        padding: 0;
+        margin: 0;
+    }
 }
 
-#entries-table td {
-    text-align: center;
-    border-right: 1px solid @table-white;
-    border-bottom: 1px solid @table-white;
-    padding: 0;
-    margin: 0;
-}
-
-#entries-table td:nth-last-child(2),
-#entries-table td:last-child,
-#entries-table th:nth-last-child(2),
-#entries-table th:last-child  {
-    border: none;
-    background-color: @bg-color !important;
-}
-
-#entries-table th:nth-last-child(2),
-#entries-table th:last-child {
-    border: none;
-}
 
 .entries-view-container {
     .profile-container();
     margin-top: -1px;
     border: 1px solid @off-white;
     padding-bottom: 0px;
-
-    width: 890px;
-}
-#entries-table {
-    background-color: white;
+    padding-top: 1em;
+    display: inline-block;
 }
 
 .entries-content {
-    .profile-content();
     margin-top: 0px;
+    margin-right: 0;
+    margin-left: 0;
 }
 
 .entries-accept-btn, .entries-reject-btn {
     .btn();
+    color: black;
+
     font-size: 7pt;
     vertical-align: top;
-    margin-top: -4px;
+    margin-top: 0px;
+    margin-bottom: 3px;
     margin-left: 3px;
+    margin-right: 3px;
 }
-.entries-accept-btn {
+
+.entries-accept-btn:hover {
+    background-color: palegreen;
+    color: black;
+}
+
+.entries-reject-btn:hover {
+    background-color: salmon;
+    color: black;
 }

--- a/src/views/collection.jade
+++ b/src/views/collection.jade
@@ -13,7 +13,7 @@ block content
                 span.user-email  #
                 span#id.user-email id
                 div.user-options
-                    div#logout leave
+                    button#leave.btn leave
 
                 div.collections-main-title statistics
-                    p.collection-stats 0 entries, 5 users
+                    p.collection-stats 0 entries, 0 members

--- a/src/views/collection/entries.jade
+++ b/src/views/collection/entries.jade
@@ -1,6 +1,8 @@
 extends ../base
 block view-specific-scripts
     script(src="/js/util/el.js")
+    script(src="/js/central.js")
+    script(src="/js/modal.js")
     script(src="/js/collection/entries.js")
 block content
     div.profile-area-wrapper

--- a/src/views/collection/users.jade
+++ b/src/views/collection/users.jade
@@ -1,6 +1,8 @@
 extends ../base
 block view-specific-scripts
     script(src="/js/util/el.js")
+    script(src="/js/modal.js")
+
     script(src="/js/collection/users.js")
 block content
     div.profile-area-wrapper
@@ -10,5 +12,5 @@ block content
         div.profile-container
             div.profile-content
                 div.user-options
-                    div#logout.collections-main-title invite user
+                    button#invite.btn invite user
                 div#members

--- a/src/views/entries.jade
+++ b/src/views/entries.jade
@@ -1,5 +1,8 @@
 extends base
 block view-specific-scripts
+    script(src="js/util/el.js")
+    script(src="js/central.js")
+    script(src="js/modal.js")
     script(src="js/entries.js")
 block content
     div.profile-area-wrapper
@@ -13,7 +16,6 @@ block content
                     thead
                         tr
                             th entry
-                            th collection
                             th.alternating-group intervention
                             th solve
                             th adapt
@@ -29,4 +31,5 @@ block content
                             th other
                             th
                             th
+
                     tbody#table-body

--- a/src/views/explore.jade
+++ b/src/views/explore.jade
@@ -1,12 +1,8 @@
 extends base
 block view-specific-scripts
-	// shameless plug
-	<!--link(rel="stylesheet" href="css/explore.css")-->
-	<!--extends all.css from base-->
-
 	// libraries
 	script(src="js/util/el.js")
-	script(src="http://d3js.org/d3.v3.min.js" charset="utf-8")
+	script(src="//d3js.org/d3.v3.min.js" charset="utf-8")
 
 	// libraries - sigma
 	script(src="js/vendor/sigma.min.js")

--- a/src/views/index.jade
+++ b/src/views/index.jade
@@ -1,11 +1,7 @@
 extends base
 block view-specific-scripts
-    <!--link(rel="stylesheet" href="css/overview.css")-->
-    <!--extends all.css from base-->
-
-
     // libraries - d3
-    script(src="http://d3js.org/d3.v3.min.js" charset="utf-8")
+    script(src="//d3js.org/d3.v3.min.js" charset="utf-8")
 
     // app
     script(src="js/util/color.js")


### PR DESCRIPTION
DONE
 - Move a lot of functionality from `window.user` to `window.api.v1`
 - Move a lot of api calls from different script files to `window.api.v1`
 - Fix modal bugs on collection and admin pages
 - Extend entry modal with option parameter for future (currently supports adding more buttons)

TODO
 - Fix modal bug on submit page
 - Hunt down every last reference to `window.user`