### PR TITLE
I79 reset explore btn

### DIFF
--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -56,13 +56,7 @@
 				n.color = n._color
 		})
 		this.filter.undo().apply()
-		this._fire('#reset')
-
-		//resets other buttons if active.
-		if($$('#listing').style.display === 'block')
-			$$('#matches').click()
-		if($$('#helpbox').style.display === 'block')
-			$$('#help').click()
+		this._fire('reset')
 	}
 
 	/* sneaky api, _ = might change so don't depend on it */

--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -16,6 +16,10 @@
  */
 (function (scope) {
 
+	function $$(id) {
+		return document.querySelector(id)
+	}
+
 	// Add a method to the graph model that returns an
 	// object with every neighbors of a node inside:
 	sigma.classes.graph.addMethod('neighbors', function(nodeId) {
@@ -41,7 +45,7 @@
 				this.select(evt.data.node)
 		})
 
-		this.evtid = document.getElementById('reset')
+		this.evtid = $$('#reset')
 			.addEventListener('click', evt => this.reset(), false)
 	}
 
@@ -52,7 +56,13 @@
 				n.color = n._color
 		})
 		this.filter.undo().apply()
-		this._fire('reset')
+		this._fire('#reset')
+
+		//resets other buttons if active.
+		if($$('#listing').style.display === 'block')
+			$$('#matches').click()
+		if($$('#helpbox').style.display === 'block')
+			$$('#help').click()
 	}
 
 	/* sneaky api, _ = might change so don't depend on it */

--- a/src/js/explore.js
+++ b/src/js/explore.js
@@ -5,19 +5,28 @@
 
 	function toggleDiv(sel) {
 		var e = $$(sel)
-		return function() {
+		 return function() {
 			if (e.style.display === 'block')
 				e.style.display = 'none'
 			else
 				e.style.display = 'block'
-
+			
 			this.classList.toggle('down')
+		}
+	}
+
+	function resetAll(div, btn){
+		var e = $$(div)
+		var button = $$(btn)
+		if (e.style.display === 'block'){
+			button.click()
 		}
 	}
 
 	var instance = undefined,
 		ctrl = undefined,
 		list = undefined
+
 	function explore(dataset, into) {
 		var graph = window.graph(dataset, window.explore_conf)
 		if (instance) {
@@ -47,6 +56,11 @@
 			list = new window.listing($$('#listing'), instance, dataset)
 			list.registerEvents(ctrl)
 
+			ctrl.bind('reset', function(){
+				resetAll('#listing','#matches')
+				resetAll('#helpbox', '#help')
+			})//resets other buttons if active.
+
 			$$('#matches').addEventListener('click', () => {
 				var showView = $$('#matches').classList.contains('down')
 				instance.graph.nodes().forEach(n => {
@@ -71,7 +85,6 @@
 		$$('#explore').classList.add('current-view')
 		$$('#help').addEventListener('click', toggleDiv('#helpbox'), false)
 		$$('#matches').addEventListener('click', toggleDiv('#listing'), false)
-
 		var hasCollection = window.location.hash.length > 0
 		var collectionId = hasCollection ? window.location.hash.substring(1) : ""
 		var found = false
@@ -120,6 +133,7 @@
 			$$('#graph').style.height = height
 			$$('#listing').style.height = height
 		}
-	}
 
+	}
+	
 })();


### PR DESCRIPTION
Updated reset button so that it now resets the functionality of the 'matches' and 'tips' button. 
Maintains which collection the user is in as it just 'presses' the other buttons if they are in use.