### PR TITLE
Implement processing of a tree taxonomy

### DIFF
--- a/app.js
+++ b/app.js
@@ -65,6 +65,10 @@ app.get("/profile", function(req, res) {
     res.render("profile");
 });
 
+app.get("/taxonomy", function(req, res) {
+    res.render("taxonomy");
+});
+
 app.get("/invitations", function(req, res) {
     res.render("invitations");
 });

--- a/src/js/tax-playground.js
+++ b/src/js/tax-playground.js
@@ -1,10 +1,11 @@
-
 window.addEventListener('load', start)
+
 
 function start() {
     document.getElementById('collection').addEventListener('change', select_collection, false)
     document.getElementById('entry').addEventListener('change', select_entry, false)
 
+    window.TARGET = document.getElementById('taxonomy')
     load_collections()
 }
 
@@ -13,24 +14,127 @@ function select_collection(evt) {
 }
 
 function select_entry(evt) {
-    load_taxonomy(+this.value)
+    inspect_entry(+this.value)
 }
 
+function clear_target() {
+    while (TARGET.lastChild)
+        TARGET.removeChild(TARGET.lastChild)
+}
+
+function inspect_entry(entry_id) {
+    clear_target()
+    load_taxonomy(+this.value).then(inspect_classification)
+}
+
+function inspect_taxonomy(entry_id) {
+    clear_target()
+    dump_taxonomy(window.tx.treeMap({}))
+}
+
+function byNbrOfChildren(a, b) {
+    return a.children.length - b.children.length
+}
+
+/* Generate a classification setup a la submit page */
+function classification_remove_row(evt) {
+    var sample = this.parentNode
+    sample.parentNode.removeChild(sample)
+}
+/* when user clicks the [+] of a facet */
+function classification_add_row(evt) {
+    var remove = el("div.remove", ["✖"])
+    remove.addEventListener('click', classification_remove_row) 
+    this.parentNode.appendChild(el('div.entity-sample', [
+        el("input"),
+        remove
+    ]))
+}
+/* when user changes the checkbox value of a facet */
+function classification_checkbox_click(evt) {
+    var header = this.parentNode
+
+    if (!this.checked) {
+        /* the [+] and inputs are siblings to the header */
+        while (header.nextSibling)
+            header.parentNode.removeChild(header.nextSibling)
+    } else {
+        // TODO: Load text from somewhere
+        var add = el("div.additional-data", ["click to add description +"])
+        add.addEventListener('click', classification_add_row, false)
+        header.parentNode.insertBefore(add, header.nextSibling)
+    }
+}
+function generate_checkbox() {
+    var box = el("input", {type:"checkbox"})
+    box.addEventListener('change', classification_checkbox_click, false)
+    return box
+}
+function generate_submit_classification() {
+    clear_target()
+
+    var taxonomy = new Taxonomy({})
+    console.log(taxonomy.tree())
+
+    /**
+     * div.classification
+     *     div.node
+     *         span "Effect"
+     *         div.leaf
+     *             div.header
+     *                 label "Solve new problem"
+     *                 input "[x]"
+     *             div.additional-data "click to add description +"
+     *             div.entity-sample
+     *                 input
+     *                 div.remove "x"
+     */
+    var cxx = el('div.classification', taxonomy.tree().map(
+        function build(node, i) {
+            if (node.isTreeLeaf()) {
+                return el("div.leaf", [
+                    el("div.header", [
+                        el("label", [node.name()]),
+                        generate_checkbox()
+                    ])
+                ])
+            } else {
+                return el("div.node", [
+                    el("span", [node.name()]),
+                    node.map(build).sort(byNbrOfChildren)
+                ])
+            }
+        }).sort(byNbrOfChildren)
+    )
+
+    var divider = el("div.center", [
+        el("div.classification-divider", [""]),
+        el("div.divider-title", ["Classification"]),
+        el("div.classification-divider", [""])
+    ])
+
+    TARGET.appendChild(el("div", [divider, cxx]))
+}
+
+console.log("collection", "462")
+console.log("entry", "313")
+console.log("inspect entry:", "load_taxonomy(eid).then(inspect_classification)")
+
+/* misc */
 function load_collections() {
-    api.v1.account.collections().then(function (collz) {
+    return api.v1.account.collections().then(function (collz) {
         var target = document.getElementById('collection')
         for (var i = 0; i < collz.length; i++) {
             var id = collz[i].id
             var name = collz[i].name
             target.appendChild(el('option', {value: id}, [`${name}/${id}`]))
         }
-        load_entries(462)
     })
 }
 
 function load_entries(coll_id) {
     document.getElementById('collection').value = coll_id
-    window.api.ajax("GET", window.api.host + "/v1/collection/" + coll_id + "/graph")
+    return window.api.ajax("GET", window.api.host + "/v1/collection/" + coll_id + "/graph")
         .then(function (graph) {
             var target = document.getElementById('entry')
             while (target.lastChild)
@@ -38,26 +142,41 @@ function load_entries(coll_id) {
             for (var i = 0; i < graph.nodes.length; i++) {
                 target.appendChild(el('option', {value: graph.nodes[i].id}, [""+graph.nodes[i].id]))
             }
-            load_taxonomy(313)
         })
 }
 
 function load_taxonomy(entry_id) {
     document.getElementById('entry').value = entry_id
-    api.v1.entry.taxonomy(entry_id).then(function (taxonomy) {
-        var target = document.getElementById('taxonomy')
-        
-        while (target.lastChild)
-            target.removeChild(target.lastChild)
-        
-        var root = window.tx.treeMap(taxonomy)
-        root = window.tx.treeShake(root)
-        var html = window.tx.htmlMap(root.tree)
-        target.appendChild(html)
-
-        console.log(taxonomy)
-        console.log(root)
-        console.log(cut)
-        console.log(html)
+    return api.v1.entry.taxonomy(entry_id).then(function (classification) {
+        var taxonomy = new Taxonomy({})
+        return taxonomy.classify(classification)
     })
+}
+
+function inspect_classification(root) {
+    dump_taxonomy(root.shake())
+}
+
+function dump_taxonomy(root) {
+    var target = document.getElementById('taxonomy')
+
+    function explore(node, depth) {
+        if (node.isEntityLeaf())
+            return el("div.entity", [node.name()])
+
+        var children = node.map((n, i) => explore(n, depth + 1))
+        if (depth > 2)
+            return children
+        
+        return el("div.sublevel.level-" + depth, [
+            node.name(),
+            children
+        ])
+    }
+
+    var html = el("div.root", [
+        root.map((n, i) => explore(n, 0))
+    ])
+
+    target.appendChild(html)
 }

--- a/src/js/tax-playground.js
+++ b/src/js/tax-playground.js
@@ -1,0 +1,63 @@
+
+window.addEventListener('load', start)
+
+function start() {
+    document.getElementById('collection').addEventListener('change', select_collection, false)
+    document.getElementById('entry').addEventListener('change', select_entry, false)
+
+    load_collections()
+}
+
+function select_collection(evt) {
+    load_entries(+this.value)
+}
+
+function select_entry(evt) {
+    load_taxonomy(+this.value)
+}
+
+function load_collections() {
+    api.v1.account.collections().then(function (collz) {
+        var target = document.getElementById('collection')
+        for (var i = 0; i < collz.length; i++) {
+            var id = collz[i].id
+            var name = collz[i].name
+            target.appendChild(el('option', {value: id}, [`${name}/${id}`]))
+        }
+        load_entries(462)
+    })
+}
+
+function load_entries(coll_id) {
+    document.getElementById('collection').value = coll_id
+    window.api.ajax("GET", window.api.host + "/v1/collection/" + coll_id + "/graph")
+        .then(function (graph) {
+            var target = document.getElementById('entry')
+            while (target.lastChild)
+                target.removeChild(target.lastChild)
+            for (var i = 0; i < graph.nodes.length; i++) {
+                target.appendChild(el('option', {value: graph.nodes[i].id}, [""+graph.nodes[i].id]))
+            }
+            load_taxonomy(313)
+        })
+}
+
+function load_taxonomy(entry_id) {
+    document.getElementById('entry').value = entry_id
+    api.v1.entry.taxonomy(entry_id).then(function (taxonomy) {
+        var target = document.getElementById('taxonomy')
+        
+        while (target.lastChild)
+            target.removeChild(target.lastChild)
+        
+        var root = window.tx.treeMap(taxonomy)
+        root = window.tx.treeShake(root)
+        var html = window.tx.htmlMap(root.tree)
+        target.appendChild(html)
+
+        console.log(taxonomy)
+        console.log(root)
+        console.log(cut)
+        console.log(html)
+    })
+}

--- a/src/js/taxonomy.js
+++ b/src/js/taxonomy.js
@@ -6,7 +6,7 @@
         this.short = short
         this.long = long
         this.tree = children
-	}
+    }
     Node.prototype.name = function() { return this.long }
     Node.prototype.id = function() { return this.short }
     /**
@@ -88,30 +88,30 @@
      * }
      */
     // identifier, name, children
-	var MOCK_TAXONOMY = new Node("root", "root", [
-		new Node("effect", "Effect", [
-			new Node("testing-adapt", "Adapt testing", [
+    var MOCK_TAXONOMY = new Node("root", "root", [
+        new Node("effect", "Effect", [
+            new Node("testing-adapt", "Adapt testing", [
                 new Node("adapting", "Adapting for new tests", []),
                 new Node("adaptation", "Adaption for other shit", [])
             ]),
-			new Node("solving", "Solve new problem", []),
-			new Node("assessing", "Assess new problem", []),
-			new Node("improving", "Improve testing", [])
-		]),
-		new Node("scope", "Scope", [
-			new Node("planning", "Test planning", []),
-			new Node("design", "Test design", []),
-			new Node("execution", "Test execution", []),
-			new Node("analysis", "Test analysis", [])
-		]),
-		new Node("context", "Context", [
-			new Node("people", "People related constraints", []),
-			new Node("information", "Availability of information", []),
-			new Node("sut", "Properties of SUT", []),
-			new Node("other", "Other", [])
-		]),
-		new Node("intervention", "Intervention", [])
-	])
+            new Node("solving", "Solve new problem", []),
+            new Node("assessing", "Assess new problem", []),
+            new Node("improving", "Improve testing", [])
+        ]),
+        new Node("scope", "Scope", [
+            new Node("planning", "Test planning", []),
+            new Node("design", "Test design", []),
+            new Node("execution", "Test execution", []),
+            new Node("analysis", "Test analysis", [])
+        ]),
+        new Node("context", "Context", [
+            new Node("people", "People related constraints", []),
+            new Node("information", "Availability of information", []),
+            new Node("sut", "Properties of SUT", []),
+            new Node("other", "Other", [])
+        ]),
+        new Node("intervention", "Intervention", [])
+    ])
 
     /**
      * A tree representation of a taxonomy.
@@ -125,7 +125,7 @@
 
         /* e.g. backend_repr is a flat list of the nodes:
           [ node, node, node, node ]
-          where node = { short, long, parse }
+          where node = { short, long, parent }
 
           var root = node("root", "root", [])
           // extremely simple algo: build tree iteratively

--- a/src/js/taxonomy.js
+++ b/src/js/taxonomy.js
@@ -1,0 +1,140 @@
+(function () {
+    function node(short, long, children) {
+		return {
+			short: short,
+			long: long,
+			tree: children
+		}
+	}
+
+	function tree(children) {
+		return node("root", "root", children)
+	}
+
+	var taxonomy = tree([
+		node("effect", "Effect", [
+			node("testing-adapt", "Adapt testing", [
+                node("adapting", "Adapting for new tests", []),
+                node("adaptation", "Adaption for other shit", [])
+            ]),
+			node("solving", "Solve new problem", []),
+			node("assessing", "Assess new problem", []),
+			node("improving", "Improve testing", [])
+		]),
+		node("scope", "Scope", [
+			node("planning", "Test planning", []),
+			node("design", "Test design", []),
+			node("execution", "Test execution", []),
+			node("analysis", "Test analysis", [])
+		]),
+		node("context", "Context", [
+			node("people", "People related constraints", []),
+			node("information", "Availability of information", []),
+			node("sut", "Properties of SUT", []),
+			node("other", "Other", [])
+		]),
+		node("intervention", "Intervention", [])
+	])
+
+	var reverse = {}
+	var shorthand = {}
+
+	function recursiveDescent(parent, current) {
+		shorthand[current.short] = current.long
+		reverse[current.short] = parent.short
+		for (var i = 0; i < current.tree.length; i++) {
+			recursiveDescent(current, current.tree[i])
+		}
+	}
+
+	function mapTaxonomy(taxonomy) {
+		for (var i = 0; i < taxonomy.tree.length; i++) {
+			recursiveDescent(taxonomy, taxonomy.tree[i])
+		}
+	}
+
+    function dfs(node, find) {
+        if (node.short === find)
+            return node
+        
+        for (var i = 0; i < node.tree.length; i++) {
+            // Might have child leaves that aren't nodes themselves
+            if (typeof node.tree[i] === "string")
+                continue
+
+            var probe = dfs(node.tree[i], find)
+            if (probe)
+                return probe
+        }
+
+        return undefined
+    }
+
+    mapTaxonomy(taxonomy)
+
+    function insertClassificationIntoTree(classification) {
+        // classification = {"SHORT": [ENTITY], "SHORT": [ENTITY]}
+        var copy = JSON.parse(JSON.stringify(taxonomy))
+        var list = Object.keys(classification)
+        for (var i = 0; i < list.length; i++) {
+            var key = list[i]
+            var values = classification[key]
+            var node = dfs(copy, key.toLowerCase())
+            
+            if (!node) {
+                console.log("Couldn't find", key.toLowerCase(), "skipping", values)
+                continue
+            }
+            node.tree = node.tree.concat(values)
+        }
+        return copy
+    }
+
+    function removeUnclassifiedTrees(root) {
+        function shake(node) {
+            if (typeof node === "string")
+                return node
+
+            for (var i = 0; i < node.tree.length; i++) {
+                var keep = shake(node.tree[i])
+                if (keep) continue
+                console.log('shaking', node.tree[i].short, 'from', node.short)
+                node.tree.splice(i, 1)
+                i--
+            }
+
+            if (node.tree.length === 0)
+                return undefined
+            
+            return node
+        }
+
+        return shake(root)
+    }
+
+    function mapTreeToHTML(tree) {
+        function explore(node, depth) {
+            if (typeof node === "string")
+                return el("div.entity", [node])
+
+            var children = node.tree.map((n, i) => explore(n, depth + 1))
+            if (depth > 2)
+                return children
+            
+            return el("div.sublevel.level-" + depth, [
+                node.long,
+                children
+            ])
+        }
+
+        return el("div.root", [
+            tree.map((n, i) => explore(n, 0))
+        ])
+    }
+
+    window.tx = {
+        treeMap: insertClassificationIntoTree,
+        treeShake: removeUnclassifiedTrees,
+        htmlMap: mapTreeToHTML
+    }
+})();

--- a/src/js/taxonomy.js
+++ b/src/js/taxonomy.js
@@ -1,68 +1,72 @@
-(function () {
-    function node(short, long, children) {
-		return {
-			short: short,
-			long: long,
-			tree: children
-		}
+"use strict";
+(function (win) {
+
+    /* Data structure of the tree */
+    function Node(short, long, children) {
+        this.short = short
+        this.long = long
+        this.tree = children
 	}
-
-	function tree(children) {
-		return node("root", "root", children)
-	}
-
-	var taxonomy = tree([
-		node("effect", "Effect", [
-			node("testing-adapt", "Adapt testing", [
-                node("adapting", "Adapting for new tests", []),
-                node("adaptation", "Adaption for other shit", [])
-            ]),
-			node("solving", "Solve new problem", []),
-			node("assessing", "Assess new problem", []),
-			node("improving", "Improve testing", [])
-		]),
-		node("scope", "Scope", [
-			node("planning", "Test planning", []),
-			node("design", "Test design", []),
-			node("execution", "Test execution", []),
-			node("analysis", "Test analysis", [])
-		]),
-		node("context", "Context", [
-			node("people", "People related constraints", []),
-			node("information", "Availability of information", []),
-			node("sut", "Properties of SUT", []),
-			node("other", "Other", [])
-		]),
-		node("intervention", "Intervention", [])
-	])
-
-	var reverse = {}
-	var shorthand = {}
-
-	function recursiveDescent(parent, current) {
-		shorthand[current.short] = current.long
-		reverse[current.short] = parent.short
-		for (var i = 0; i < current.tree.length; i++) {
-			recursiveDescent(current, current.tree[i])
-		}
-	}
-
-	function mapTaxonomy(taxonomy) {
-		for (var i = 0; i < taxonomy.tree.length; i++) {
-			recursiveDescent(taxonomy, taxonomy.tree[i])
-		}
-	}
-
-    function dfs(node, find) {
-        if (node.short === find)
-            return node
+    Node.prototype.name = function() { return this.long }
+    Node.prototype.id = function() { return this.short }
+    /**
+     * We have two types of leaf nodes:
+     *   - nodes that have no children
+     *   - nodes that are entities
+     * Depending on what we do with the tree we want to interpret leaves
+     * differently, e.g. tree shaking stops if it finds an entity leaf.
+     */
+    Node.prototype.isTreeLeaf = function () { return this.tree.length === 0 }
+    Node.prototype.isEntityLeaf = function() { return this.id() === "leaf" }
+    Node.prototype.isRoot = function() { return this.id() === "root" }
+    Node.prototype.addChild = function(c) { this.tree.push(c) }
+    Node.prototype.clone = function(deep) {
+        var newNode = new Node(this.id(), this.name(), [])
         
-        for (var i = 0; i < node.tree.length; i++) {
-            // Might have child leaves that aren't nodes themselves
-            if (typeof node.tree[i] === "string")
-                continue
+        for (var i = 0; deep & i < this.tree.length; i++) {
+            newNode.addChild(this.tree[i].clone(deep))
+        }
 
-            var probe = dfs(node.tree[i], find)
+        return newNode
+    }
+
+    /**
+     * map is a bit special since it only maps children.
+     * rationale is that you have the root object anyway
+     * and it's easier this way to decide if you want it
+     * in the new structure, or not.
+     */
+    Node.prototype.map = function(fn) { return this.tree.map(fn) }
+    
+    /**
+     * Recursively remove nodes without any entity leaves.
+     */
+    Node.prototype.shake = function () {
+        if (this.isEntityLeaf())
+            return true
+
+        for (var i = 0; i < this.tree.length; i++) {
+            var keep = this.tree[i].shake()
+            if (keep) continue
+            this.tree.splice(i, 1)
+            i--
+        }
+
+        if (this.isTreeLeaf())
+            return undefined
+        
+        return this
+    }
+
+    /**
+     * Depth-first search for node with id.
+     */
+    Node.prototype.dfs = function(id) {
+        if (this.id() === id)
+            return this
+        
+        for (var i = 0; i < this.tree.length; i++) {
+            var probe = this.tree[i].dfs(id)
             if (probe)
                 return probe
         }
@@ -70,71 +74,102 @@
         return undefined
     }
 
-    mapTaxonomy(taxonomy)
+    /**
+     * Mock taxonomy
+     * 
+     * tree = {
+     *     long = short = "root",
+     *     tree = [
+     *         { long = short = "Effect", tree = [ ... ] },
+     *         { long = short = "Scope", tree = [ ... ] },
+     *         { long = short = "Context", tree = [ ... ] },
+     *         { long = short = "Intervention", tree = [] }
+     *     ]
+     * }
+     */
+    // identifier, name, children
+	var MOCK_TAXONOMY = new Node("root", "root", [
+		new Node("effect", "Effect", [
+			new Node("testing-adapt", "Adapt testing", [
+                new Node("adapting", "Adapting for new tests", []),
+                new Node("adaptation", "Adaption for other shit", [])
+            ]),
+			new Node("solving", "Solve new problem", []),
+			new Node("assessing", "Assess new problem", []),
+			new Node("improving", "Improve testing", [])
+		]),
+		new Node("scope", "Scope", [
+			new Node("planning", "Test planning", []),
+			new Node("design", "Test design", []),
+			new Node("execution", "Test execution", []),
+			new Node("analysis", "Test analysis", [])
+		]),
+		new Node("context", "Context", [
+			new Node("people", "People related constraints", []),
+			new Node("information", "Availability of information", []),
+			new Node("sut", "Properties of SUT", []),
+			new Node("other", "Other", [])
+		]),
+		new Node("intervention", "Intervention", [])
+	])
 
-    function insertClassificationIntoTree(classification) {
-        // classification = {"SHORT": [ENTITY], "SHORT": [ENTITY]}
-        var copy = JSON.parse(JSON.stringify(taxonomy))
+    /**
+     * A tree representation of a taxonomy.
+     */
+    function Taxonomy(backend_repr) {
+        this.child2parent = {}
+        this.short2long = {}
+
+        // TODO: Generate root from backend_repr
+        this.root = MOCK_TAXONOMY.clone(true)
+
+        /* e.g. backend_repr is a flat list of the nodes:
+          [ node, node, node, node ]
+          where node = { short, long, parse }
+
+          var root = node("root", "root", [])
+          // extremely simple algo: build tree iteratively
+          // if node has parent we add it, otherwise we add back
+          while (backend_repr.length > 0) {
+              var current = backend_repr.shift()
+              var parent = dfs(root, current.parent)
+              if (parent)
+                  parent.tree.push(node(current.short, current.long, []))
+              else
+                  backend_repr.push(current)
+          }
+        */
+    }
+
+    /**
+     * Update the root or get a copy of the tree.
+     */
+    Taxonomy.prototype.tree = function (new_root) {
+        if (new_root)
+            this.root = new_root
+        else
+            return this.root.clone(true)
+    }
+
+    /**
+     * Inserts a classification into a new tree. 
+     */
+    Taxonomy.prototype.classify = function (classification) {
+        var copy = this.tree()
         var list = Object.keys(classification)
         for (var i = 0; i < list.length; i++) {
             var key = list[i]
             var values = classification[key]
-            var node = dfs(copy, key.toLowerCase())
+            var node = copy.dfs(key.toLowerCase())
             
-            if (!node) {
-                console.log("Couldn't find", key.toLowerCase(), "skipping", values)
-                continue
+            if (!node) continue
+            for (var j = 0; j < values.length; j++) {
+                var entity = values[j]
+                node.addChild(new Node("leaf", entity, []))
             }
-            node.tree = node.tree.concat(values)
         }
         return copy
     }
 
-    function removeUnclassifiedTrees(root) {
-        function shake(node) {
-            if (typeof node === "string")
-                return node
-
-            for (var i = 0; i < node.tree.length; i++) {
-                var keep = shake(node.tree[i])
-                if (keep) continue
-                console.log('shaking', node.tree[i].short, 'from', node.short)
-                node.tree.splice(i, 1)
-                i--
-            }
-
-            if (node.tree.length === 0)
-                return undefined
-            
-            return node
-        }
-
-        return shake(root)
-    }
-
-    function mapTreeToHTML(tree) {
-        function explore(node, depth) {
-            if (typeof node === "string")
-                return el("div.entity", [node])
-
-            var children = node.tree.map((n, i) => explore(n, depth + 1))
-            if (depth > 2)
-                return children
-            
-            return el("div.sublevel.level-" + depth, [
-                node.long,
-                children
-            ])
-        }
-
-        return el("div.root", [
-            tree.map((n, i) => explore(n, 0))
-        ])
-    }
-
-    window.tx = {
-        treeMap: insertClassificationIntoTree,
-        treeShake: removeUnclassifiedTrees,
-        htmlMap: mapTreeToHTML
-    }
-})();
+    win.Taxonomy = Taxonomy
+})(window);

--- a/src/less/taxonomy.less
+++ b/src/less/taxonomy.less
@@ -1,0 +1,6 @@
+@import 'src/less/workingfiles/grid.less';
+@import 'src/less/workingfiles/mixins.less';
+@import 'src/less/workingfiles/style.less';
+@import 'src/less/workingfiles/media.less';
+@import 'src/less/workingfiles/submit.less';
+@import 'src/less/workingfiles/taxonomy.less';

--- a/src/less/workingfiles/taxonomy.less
+++ b/src/less/workingfiles/taxonomy.less
@@ -1,0 +1,15 @@
+.root {
+    font-size: 2em;
+}
+
+.root > .sublevel { margin-left: 0em; }
+
+.sublevel {
+    font-size: 0.85em;
+    margin-left: 1.5em;
+}
+
+.entity {
+    font-size: 0.80em;
+    margin-left: 1.5em;
+}

--- a/src/less/workingfiles/taxonomy.less
+++ b/src/less/workingfiles/taxonomy.less
@@ -1,15 +1,68 @@
-.root {
-    font-size: 2em;
+// inspect classification
+#taxonomy {
+    font-size: 1.5em;
 }
-
 .root > .sublevel { margin-left: 0em; }
-
 .sublevel {
     font-size: 0.85em;
     margin-left: 1.5em;
 }
-
 .entity {
     font-size: 0.80em;
     margin-left: 1.5em;
+}
+.center { text-align: center;}
+
+// generate submit page selectors
+
+.classification {
+    font-size: 14pt;
+
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+
+    text-align: right;
+
+    .leaf { 
+        font-size: 0.9em; 
+
+        > .header {
+            display: flex;
+            justify-content: flex-end;
+            
+            > label { font-size: 0.9em; }
+        }
+    }
+
+    .node { font-size: 0.9em; }
+    > .node, >.leaf { margin: 0.5em; }
+}
+
+.entity-sample {
+    display: flex;
+
+    /* make sure that input and remove are aligned vertically */
+    align-items: center;
+
+    /* items are aligned with right border */
+    justify-content: flex-end;
+
+    &:not(:last-child) {
+        margin-bottom: 0.1em;
+    }
+
+    input {
+        /* style input here */
+    }
+
+    .remove {
+        font-size: 1rem;
+        margin-left: 5px;
+        margin-right: -1rem;
+        &:hover {
+            cursor: pointer;
+            color: indianred;
+        }
+    }
 }

--- a/src/views/taxonomy.jade
+++ b/src/views/taxonomy.jade
@@ -1,0 +1,14 @@
+extends base
+block view-specific-scripts
+    link(rel='stylesheet', href='/css/taxonomy.css')
+
+    // app
+    script(src="js/util/el.js")
+    script(src="js/taxonomy.js")
+    script(src="js/tax-playground.js")
+
+block content
+    h1 taxonomy playground
+    select#collection
+    select#entry
+    div#taxonomy


### PR DESCRIPTION
Alright, this is a :construction: not ready for merge yet.

I've implemented a number of tree processors to help us with the upcoming dynamic taxonomy:
 - `treeMap`: given a tree taxonomy and a flat classification it can add entities to the correct taxonomy nodes
 - `treeShake`: remove all nodes that have no children
 - `htmlMap`: map a tree to a simple html structure

I've also added a temporary page (`/taxonomy`) that does the above to show a modal-like view of an entry's classification.

The underlying assumption is that we can, at some point, (re)construct the taxonomy as a tree. No matter what structure the backend gives us, it must contain enough information to create the tree.