### PR TITLE
included Enter Key functionality to login on Login Page

### DIFF
--- a/src/js/login.js
+++ b/src/js/login.js
@@ -67,11 +67,19 @@ $(document).ready(function() {
         $("#login-btn").prop("disabled", false).removeClass("submit-disabled")
     }
 
-    //
+    //    
+    //allows user to press Enter Key to login. Timeout is for functionality on chrome
+    document.addEventListener('keydown', (evt) => {
+        if (evt.keyCode !== 13)
+            return
+        setTimeout(function() {
+            $("#login-btn").click()
+        }, 50)
+    }, false)
 
     $("#login-btn").on("click", function(evt) {
         var email = $("#email").val();
-
+        
         disableButtons()
         clearComplaints()
 


### PR DESCRIPTION
Users should be now able to use the Enter Key to login on the login page. This should also work where a user has their user name and password stored in their browser and goes onto the Login Page and can just press enter to log in without clicking on the page or interacting with the page in any other way.