### PR TITLE
Fixed bug on safari - flexbox not working for classification dividers

### DIFF
--- a/src/less/workingfiles/submit.less
+++ b/src/less/workingfiles/submit.less
@@ -428,7 +428,10 @@ th {
 .classification-divider {
     .divider();
     width: 100%;
+    flex-grow: 1;
+    flex-basis: 1;
 }
+    
 .queued-divider {
     .divider();
     width: 30%;


### PR DESCRIPTION
There was a small bug on the submit page where the line dividers breaking the headers 'Classification' and 'Queued Submissions' were not working properly. 
If possible test on old versions of safari and other browsers to see if its working. 
Tested & Working appropriately on 

Safari - Version 9.0.3  
Firefox - Version 52
Chrome - Version 56