### PR TITLE
Empty cells are no longer included in the import, given that a heading was specified.

### DIFF
--- a/src/js/import.js
+++ b/src/js/import.js
@@ -238,7 +238,6 @@
         var jsons = createjsons(lines, CSVHeaders);
         var allEntries = jsonToEntry(jsons);
         var validEntries = allEntries.validEntries;
-        console.log(validEntries); //remove
 
         if (printStatistics(allEntries, "CSV")){
             createCollection(validEntries, newCollectionName, pushEntry, modal);
@@ -417,10 +416,11 @@
           map((i, e) => e.value).toArray();
       var currentHeader = serp.find(value => value.display === labels[j]);
       var isTaxonomyLeaf = serpTaxonomyLeaves.indexOf(currentHeader) !== -1;
-
       var currentValue = calculateCurrentValue(CSVHeaders, currentLine, onlySelectedInputs, isTaxonomyLeaf);
-      var root = isTaxonomyLeaf ? serpClassification : jsonObj;
-      root[currentHeader.value] = currentValue;
+      if(isValueValid(currentValue, selectedFirst[j].className, onlySelectedInputs.length)){
+        var root = isTaxonomyLeaf ? serpClassification : jsonObj;
+        root[currentHeader.value] = currentValue;
+      }
     }
     jsonObj.serpClassification = serpClassification;
     jsonObj.entryType = entryType;
@@ -433,16 +433,18 @@
       currentValue = isTaxonomyLeaf ? ["unspecified"] : "unspecified";
     } else {
       currentValue = isTaxonomyLeaf ? [] : "";
+      var firstValueHasBeenAdded = false;
       for(var k=0;k<onlySelectedInputs.length;k++){
-          var currentCell = currentLine[CSVHeaders.indexOf(onlySelectedInputs[k])];
-          if(currentCell){
-            if(isTaxonomyLeaf){
-              currentValue.push(currentCell);
-            } else {
-              var separator = k === 0 ? "" : ", ";
-              currentValue = currentValue + separator + currentCell;
-            }
+        var currentCell = currentLine[CSVHeaders.indexOf(onlySelectedInputs[k])];
+        if(currentCell){
+          if(isTaxonomyLeaf){
+            currentValue.push(currentCell);
+          } else {
+            var separator = firstValueHasBeenAdded ? ", " : "";
+            currentValue = currentValue + separator + currentCell;
+            firstValueHasBeenAdded = true;
           }
+        }
       }
       if(!currentValue){
         currentValue = "unspecified";
@@ -451,6 +453,22 @@
       }
     }
     return currentValue;
+  }
+
+  function isValueValid(currentValue, checkboxClassName, specifiedInputsLength){
+    if (currentValue === "unspecified" || currentValue[0] === "unspecified"){
+      if (specifiedInputsLength !== 0){
+        if (checkboxClassName === "import-checkbox first researchMustHave" ||
+            checkboxClassName === "import-checkbox first challengeMustHave"){
+              return true;
+        }
+      } else {
+        return true;
+      }
+    } else {
+      return true;
+    }
+    return false;
   }
 
   // Function is taken from stackoverflow,


### PR DESCRIPTION
When importing: If a heading in the CSV is not specified (i.e. user just clicked the button and did not selected anything in the dropdown) the taxonomy leaf of all the entries should be given a value of "unspecified". However, if the user specifies a heading, cells which are empty will no longer give the json object the value "unspecified", but rather not include them at all. 

Easiest way to verify that it works is probably to test the system on a CSV file. It should look like the picture and not the whole column filled. 
![should_look](https://cloud.githubusercontent.com/assets/15870660/24668753/454525b8-1968-11e7-9abf-f434a3690111.png)

Also, I changed a minor bug where the string concatenation was not functioning properly. 