### PR TITLE
New design facilitates node selection and adding leaves

### DIFF
--- a/src/js/import.js
+++ b/src/js/import.js
@@ -238,7 +238,7 @@
         var jsons = createjsons(lines, CSVHeaders);
         var allEntries = jsonToEntry(jsons);
         var validEntries = allEntries.validEntries;
-        
+
         if (printStatistics(allEntries, "CSV")){
             createCollection(validEntries, newCollectionName, pushEntry, modal);
         }
@@ -397,15 +397,15 @@
 
   function createjsons(lines, CSVHeaders){
     function byNodeSelection(i, el) {
-        var node = el.querySelector(".import-node-selection");
-        return node && node.value === "everything";
+      var node = el.querySelector(".import-node-selection");
+      return node && node.value === "everything";
     }
     function byImportSelection(i, el) {
-        var select = el.querySelector(".import-select");
-        return select && select.value !== "unspecified";
+      var select = el.querySelector(".import-select");
+      return select && select.value !== "unspecified";
     }
     var selectedNodes = $(".import-all-selects-wrapper").filter(function (i, el) {
-        return byNodeSelection(i, el) || byImportSelection(i, el)
+      return byNodeSelection(i, el) || byImportSelection(i, el)
     })
 
     if(entryType === "research"){
@@ -427,8 +427,8 @@
     var serpClassification = {};
     for(var j=0;j<selectedNodes.length;j++){
       var onlySelectedInputs = $(selectedNodes[j]).
-          find(".import-select").filter(function(i, el) {return el.value !== "unspecified";}).
-          map((i, e) => e.value).toArray();
+        find(".import-select").filter(function(i, el) {return el.value !== "unspecified";}).
+        map((i, e) => e.value).toArray();
 
       var label = $(selectedNodes[j]).find("label").text();
       var currentHeader = serp.find(value => value.display === label);
@@ -476,26 +476,14 @@
 
   function isValueValid(currentValue, currentNode, includeFor){
     if (includeFor === "everything")
-        return true;
+      return true;
 
     if (currentValue !== "unspecified" && currentValue[0] !== "unspecified")
-        return true;
+      return true;
 
     var classes = currentNode.classList;
     return  classes.contains("researchMustHave") ||
             classes.contains("challengeMustHave");
-
-    // if (currentValue === "unspecified" || currentValue[0] === "unspecified"){
-    //   if(   currentNode.className === "import-all-selects-wrapper researchMustHave"
-    //      || currentNode.className === "import-all-selects-wrapper challengeMustHave"
-    //      || includeFor === "everything") {
-    //        return true;
-    //   } else {
-    //     return false;
-    //   }
-    // } else {
-    //   return true;
-    // }
   }
 
   // Function is taken from stackoverflow,

--- a/src/js/import.js
+++ b/src/js/import.js
@@ -238,7 +238,7 @@
         var jsons = createjsons(lines, CSVHeaders);
         var allEntries = jsonToEntry(jsons);
         var validEntries = allEntries.validEntries;
-
+        
         if (printStatistics(allEntries, "CSV")){
             createCollection(validEntries, newCollectionName, pushEntry, modal);
         }
@@ -396,18 +396,24 @@
   }
 
   function createjsons(lines, CSVHeaders){
-    var selectedNodes = $(".import-node-selection").filter(function(i, el) {
-                          return el.value === "everything";
-                        }).parent().parent().add($(".import-select").filter(function(i, el) {
-                          return el.value !== "unspecified";
-                        }).parent().parent().parent());
+    function byNodeSelection(i, el) {
+        var node = el.querySelector(".import-node-selection");
+        return node && node.value === "everything";
+    }
+    function byImportSelection(i, el) {
+        var select = el.querySelector(".import-select");
+        return select && select.value !== "unspecified";
+    }
+    var selectedNodes = $(".import-all-selects-wrapper").filter(function (i, el) {
+        return byNodeSelection(i, el) || byImportSelection(i, el)
+    })
+
     if(entryType === "research"){
       selectedNodes = selectedNodes.add(".import-all-selects-wrapper.researchMustHave");
     } else if(entryType === "challenge"){
       selectedNodes = selectedNodes.add(".import-all-selects-wrapper.challengeMustHave");
     }
     var jsons = [];
-
     for(var i=1;i<lines.length;i++){
       var currentLine = lines[i];
       var jsonObj = calculateCurrentEntry(CSVHeaders, currentLine, selectedNodes);
@@ -429,6 +435,7 @@
       var isTaxonomyLeaf = serpTaxonomyLeaves.indexOf(currentHeader) !== -1;
       var currentValue = calculateCurrentValue(CSVHeaders, currentLine, onlySelectedInputs, isTaxonomyLeaf);
       var includeFor = $(selectedNodes[j]).find(".import-node-selection").val();
+
       if(isValueValid(currentValue, selectedNodes[j], includeFor)){
         var root = isTaxonomyLeaf ? serpClassification : jsonObj;
         root[currentHeader.value] = currentValue;
@@ -468,17 +475,27 @@
   }
 
   function isValueValid(currentValue, currentNode, includeFor){
-    if (currentValue === "unspecified" || currentValue[0] === "unspecified"){
-      if(   currentNode.className === "import-all-selects-wrapper researchMustHave"
-         || currentNode.className === "import-all-selects-wrapper challengeMustHave"
-         || includeFor === "everything") {
-           return true;
-      } else {
-        return false;
-      }
-    } else {
-      return true;
-    }
+    if (includeFor === "everything")
+        return true;
+
+    if (currentValue !== "unspecified" && currentValue[0] !== "unspecified")
+        return true;
+
+    var classes = currentNode.classList;
+    return  classes.contains("researchMustHave") ||
+            classes.contains("challengeMustHave");
+
+    // if (currentValue === "unspecified" || currentValue[0] === "unspecified"){
+    //   if(   currentNode.className === "import-all-selects-wrapper researchMustHave"
+    //      || currentNode.className === "import-all-selects-wrapper challengeMustHave"
+    //      || includeFor === "everything") {
+    //        return true;
+    //   } else {
+    //     return false;
+    //   }
+    // } else {
+    //   return true;
+    // }
   }
 
   // Function is taken from stackoverflow,

--- a/src/less/workingfiles/submit.less
+++ b/src/less/workingfiles/submit.less
@@ -122,8 +122,8 @@ input[type="radio"] {display:none;}
     vertical-align: top;
     font-size: @facet-title-size;
     color: black;
-    display: inline-block;
-    width: 100%;
+    text-align: center;
+    width: 455px;
     margin-top: 5px;
 }
 
@@ -141,7 +141,7 @@ input[type="radio"] {display:none;}
 }
 
 .import-extra-headings {
-    max-width: 405px;
+    max-width: 345px;
 }
 
 .import-checkbox-and-select {
@@ -154,7 +154,15 @@ input[type="radio"] {display:none;}
     display: flex;
     justify-content: space-between;
     width: 100%;
-    max-width: 250px;
+    max-width: 340px;
+}
+
+.import-node-selection {
+    max-height: 22px;
+}
+
+.import-select {
+    max-width: 95px;
 }
 
 input.import-checkbox.extra[type=checkbox]:before {
@@ -289,7 +297,7 @@ div .table-cell-div{
     width: 16rem;
     overflow: hidden;
 }
-  
+
 
 td {
     &:first-child {
@@ -431,7 +439,7 @@ th {
     flex-grow: 1;
     flex-basis: 1;
 }
-    
+
 .queued-divider {
     .divider();
     width: 30%;


### PR DESCRIPTION
Closes #114 

For each node, there are now 2 dropdown menus. The one on the left is used for node selection. The option "only if related free-text examples are extracted" will work as it does now, i. e. only include the node for entries for which there is a non-empty cell in the CSV. The option "for all entries" will include the node in all of the entries with the value "unspecified". If some mapping is done when the option "for all entries" is selected, the entries that have a non-empty value in the CSV will get that value and the other ones will get "unspecified". 