### PR TITLE
I120 import specify leaf delimiter

### DIFF
--- a/src/js/import.js
+++ b/src/js/import.js
@@ -235,8 +235,9 @@
       var newCollectionName = document.getElementById("importCollectionName").value;
       var collectionNameValid = isCollectionNameValid(newCollectionName);
       var entryTypeValid = isEntryTypeDataValid();
+      var delimitersValid = areDelimitersValid();
 
-      if(collectionNameValid && entryTypeValid){
+      if(collectionNameValid && entryTypeValid && delimitersValid){
         var jsons = createjsons(lines, CSVHeaders);
         var allEntries = jsonToEntry(jsons);
         var validEntries = allEntries.validEntries;
@@ -246,7 +247,7 @@
         }
       } else {
         $(uploadBtn).parent().append(
-          el("div.complaint.import", {text:"Information missing"})
+          el("div.complaint.import", {text:"Incorrect input"})
         );
       }
     });
@@ -346,10 +347,10 @@
   }
 
   function delimiterDiv(name, text){
-    return  el("div.import-all-selects-wrapper." + "delimiter" + name, [
-                el("div.import-select-first-box-wrapper." + "delimiter" + name, [
+    return  el("div.import-wrapper-delimiter." + name, {id: "delimiter" + name}, [
+                el("div.div-import-delimiter." + name, [
                     el("label", [text]),
-                    el("select#selectDelimiter" + name, [
+                    el("select.select-delimiter", {id: "selectDelimiter" + name}, [
                         delimiters.map(delimiter =>
                         el('option', { value: delimiter.value }, [ delimiter.display ])),
                     ])
@@ -401,6 +402,16 @@
       );
     }
     return validEntryTypeData;
+  }
+
+  function areDelimitersValid(){
+    if(selectDelimiterCSV.value === selectDelimiterLeaf.value){
+      document.getElementById("delimiterCSV").appendChild(
+          el("div.complaint.import", {text:"The delimiters have to be different"})
+      );
+      return false;
+    }
+    return true;
   }
 
   function createjsons(lines, CSVHeaders){

--- a/src/js/import.js
+++ b/src/js/import.js
@@ -347,7 +347,7 @@
   }
 
   function delimiterDiv(name, text){
-    return  el("div.import-wrapper-delimiter." + name, {id: "delimiter" + name}, [
+    return  el("div", {id: "delimiter" + name}, [
                 el("div.div-import-delimiter." + name, [
                     el("label", [text]),
                     el("select.select-delimiter", {id: "selectDelimiter" + name}, [

--- a/src/js/import.js
+++ b/src/js/import.js
@@ -348,9 +348,9 @@
 
   function delimiterDiv(name, text){
     return  el("div", {id: "delimiter" + name}, [
-                el("div.div-import-delimiter." + name, [
+                el("div.import-div-delimiter." + name, [
                     el("label", [text]),
-                    el("select.select-delimiter", {id: "selectDelimiter" + name}, [
+                    el("select.import-select-delimiter", {id: "selectDelimiter" + name}, [
                         delimiters.map(delimiter =>
                         el('option', { value: delimiter.value }, [ delimiter.display ])),
                     ])

--- a/src/js/import.js
+++ b/src/js/import.js
@@ -405,13 +405,13 @@
   }
 
   function areDelimitersValid(){
-    if(selectDelimiterCSV.value === selectDelimiterLeaf.value){
-      document.getElementById("delimiterCSV").appendChild(
-          el("div.complaint.import", {text:"The delimiters have to be different"})
-      );
-      return false;
+    if(selectDelimiterCSV.value !== selectDelimiterLeaf.value){
+      return true;
     }
-    return true;
+    document.getElementById("delimiterCSV").appendChild(
+        el("div.complaint.import", {text:"The delimiters have to be different"})
+    );
+    return false;
   }
 
   function createjsons(lines, CSVHeaders){

--- a/src/js/import.js
+++ b/src/js/import.js
@@ -240,7 +240,6 @@
         var jsons = createjsons(lines, CSVHeaders);
         var allEntries = jsonToEntry(jsons);
         var validEntries = allEntries.validEntries;
-console.log(validEntries);
 
         if (printStatistics(allEntries, "CSV")){
             createCollection(validEntries, newCollectionName, pushEntry, modal);

--- a/src/less/workingfiles/submit.less
+++ b/src/less/workingfiles/submit.less
@@ -157,13 +157,13 @@ input[type="radio"] {display:none;}
     max-width: 340px;
 }
 
-.div-import-delimiter {
+.import-div-delimiter {
     display: inline-block;
     max-width: 350px;
     width: 100%;
 }
 
-.select-delimiter {
+.import-select-delimiter {
     float: right;
 }
 

--- a/src/less/workingfiles/submit.less
+++ b/src/less/workingfiles/submit.less
@@ -157,6 +157,16 @@ input[type="radio"] {display:none;}
     max-width: 340px;
 }
 
+.div-import-delimiter {
+    display: inline-block;
+    max-width: 350px;
+    width: 100%;
+}
+
+.select-delimiter {
+    float: right;
+}
+
 .import-node-selection {
     max-height: 22px;
 }


### PR DESCRIPTION
A taxonomy leaf delimiter can now be specified when importing from CSV in addition to the CSV delimiter. 

Would appreciate if someone tested this with a file with a CSV delimiter different from comma ( , ).

If a cell in the CSV looks like (test|test2) and gets mapped to some taxonomy node and the leaf delimiter is "|", the value of that entry should be an array consisting of ["test, "test2"]. 