### PR TITLE
Fix new collection modal on submit page

### DIFF
--- a/src/js/submit.js
+++ b/src/js/submit.js
@@ -506,7 +506,7 @@ $(document).ready(function() {
         modals.optionsModal(newCollectionModal, function (name) {
             api.v1.collection.create(name)
                 .done(ok => {
-                    document.body.removeChild(this.modal)
+                    modals.clearAll()
                     querystring.c = ok.id
                     updateCollectionList()
                 })


### PR DESCRIPTION
The new collection modal on the submit page stopped working. Probably caused by some change in the DOM. The new behaviour relies on `modals.clearAll()` instead of doing `this.modal.parentNode.removeChild(this.modal)` or something similar.