### PR TITLE
notice of verification email - i136

### DIFF
--- a/src/js/components/notice-modal.js
+++ b/src/js/components/notice-modal.js
@@ -2,27 +2,26 @@
 
 	//Simple modal, with a title, some text and a button to close 
 	//the modal which can be assigned a function too
-	G.noticeModal = function(title, desc, method) {
- 	      var continueBtn = el('button#continue.btn', ['continue'])
- 	      var modal = 
- 	      			el('div.modal.notice', [
- 	              	el('div', [
- 	                el("div.modal-header-title", [title]),
- 	                el("div#bottom-divider.modal-divider"),
- 	                el("div", [desc]),
- 	                continueBtn
- 	            ])
- 	          ])
+	G.noticeModal = function(title, desc) {
+		var continueBtn = el('button#continue.btn', ['continue'])
+		var modal = el('div.modal.notice', [
+			el('div', [
+				el("div.modal-header-title", [title]),
+				el("div#bottom-divider.modal-divider"),
+				el("div", [desc]),
+				continueBtn
+			])
+		])
 
-		continueBtn.addEventListener('click', (evt) => {
-			window.modals.toggleButtonState()
-			method.apply({modal})
-		}, false)
+		return new Promise(function (F, R) {
+			document.body.appendChild(modal)
+			window.modals.appear(modal)
 
-		window.modalsEvt.pardonEvents()
-		document.body.appendChild(modal)
-		window.modals.appear(modal)
-
+			continueBtn.addEventListener('click', (evt) => {
+				document.body.removeChild(modal)
+				F()
+			}, false)
+		})
 	}
 
 })(window.components || (window.components = {}));

--- a/src/js/components/notice-modal.js
+++ b/src/js/components/notice-modal.js
@@ -1,0 +1,28 @@
+(function (G) {
+
+	//Simple modal, with a title, some text and a button to close 
+	//the modal which can be assigned a function too
+	G.noticeModal = function(title, desc, method) {
+ 	      var continueBtn = el('button#continue.btn', ['continue'])
+ 	      var modal = 
+ 	      			el('div.modal.notice', [
+ 	              	el('div', [
+ 	                el("div.modal-header-title", [title]),
+ 	                el("div#bottom-divider.modal-divider"),
+ 	                el("div", [desc]),
+ 	                continueBtn
+ 	            ])
+ 	          ])
+
+		continueBtn.addEventListener('click', (evt) => {
+			window.modals.toggleButtonState()
+			method.apply({modal})
+		}, false)
+
+		window.modalsEvt.pardonEvents()
+		document.body.appendChild(modal)
+		window.modals.appear(modal)
+
+	}
+
+})(window.components || (window.components = {}));

--- a/src/js/login.js
+++ b/src/js/login.js
@@ -55,7 +55,7 @@ $(document).ready(function() {
 
         notice = "To get full functionality from this website you need to verify your account. An email has been sent to your registered address, please follow the included instructions to complete the process."        
         req.done(xhr => {
-            window.modals.noticeModal("Almost done...", notice, toProfile)
+            window.components.noticeModal("Almost done...", notice, toProfile)
         })
 
         req.fail(xhr => {

--- a/src/js/login.js
+++ b/src/js/login.js
@@ -14,6 +14,10 @@ $(document).ready(function() {
         $(".complaint").remove()
     }
 
+    function toProfile(){
+        window.location = "profile.html"
+    }
+
     function complainSomeMore(where, what) {
         $(where).append(el("div").addClass("complaint").text(what));
     }
@@ -44,12 +48,15 @@ $(document).ready(function() {
             enableButtons()
             $("#password").val("")
         })
-    }
+    }   
 
     function register(email, passw) {
         var req = window.user.register(email, passw)
 
-        req.done(xhr => window.location = "profile.html")
+        notice = "To get full functionality from this website you need to verify your account. An email has been sent to your registered address, please follow the included instructions to complete the process."        
+        req.done(xhr => {
+            window.modals.noticeModal("Almost done...", notice, toProfile)
+        })
 
         req.fail(xhr => {
             enableButtons()

--- a/src/js/login.js
+++ b/src/js/login.js
@@ -53,9 +53,9 @@ $(document).ready(function() {
     function register(email, passw) {
         var req = window.user.register(email, passw)
 
-        notice = "To get full functionality from this website you need to verify your account. An email has been sent to your registered address, please follow the included instructions to complete the process."        
+        var notice = "To get full functionality from this website you need to verify your account. An email has been sent to your registered address, please follow the included instructions to complete the process."        
         req.done(xhr => {
-            window.components.noticeModal("Almost done...", notice, toProfile)
+            window.components.noticeModal("Almost done...", notice).then(toProfile)
         })
 
         req.fail(xhr => {

--- a/src/js/modal.js
+++ b/src/js/modal.js
@@ -125,10 +125,8 @@ $(document).ready(function() {
 		    submitToCollection($('#exportSelect').val())
 	    })
 
-		setTimeout(function(){
-			document.getElementById('modal').classList.add('appear');
-		}, modalAnimation)
         document.body.appendChild(modal)
+		modals.appear(modal)
 	}
 
 	/* Inspect facets modal */
@@ -148,9 +146,7 @@ $(document).ready(function() {
 		])
 
         document.body.appendChild(modal)
-        setTimeout(function(){
-			document.getElementById('modal').classList.add('appear');
-		}, modalAnimation)
+        modals.appear(modal)
 	 }
 
 	 /* Inspect facets modal with taxonomy extension for collection */
@@ -394,9 +390,7 @@ $(document).ready(function() {
         });
 
         document.body.appendChild(modal)
-        setTimeout(function(){
-			document.getElementById('modal').classList.add('appear');
-		}, modalAnimation)
+        modals.appear(modal)
 
         //start from 1 as root already created
 
@@ -452,75 +446,7 @@ $(document).ready(function() {
 
 		document.body.appendChild(modal)
 	}
-
-/**
-	 * Create a modal that displays allows extension of a taxonomy for a given collection
-     * div.classification
-     *     div.node
-     *         span "Effect"
-     *         div.leaf
-     *             div.header
-     *                 label "Solve new problem"
-     *                 input "[x]"
-     *             div.additional-data "click to add description +"
-     *             div.entity-sample
-     *                 input
-     *                 div.remove "x"
-	 * */
-	modals.taxonomyModal = function(cID, name) {
-       	var saveBtn = el('button#saveBtn.btn', ['save'])
-   	    var taxonomy = new Taxonomy([])
-   	    // var name = el('span', [name])
-	    var cxx = el('div.classification#classification', taxonomy.tree().map(
-	        function build(node, i) {
-	            if (node.isTreeLeaf()) {
-	                return el("div.leaf", [
-	                    el("div.header", [
-	                        el("label", [node.name()]),
-	                      	 window.taxFunc.generate_button()
-	                    ])
-	                ])
-	            } else {
-	                return el("div.node", [
-	                    el("span", [node.name()]),
-	                    node.map(build).sort(window.taxFunc.byNbrOfChildren)
-	                ])
-	            }
-	        }).sort(window.taxFunc.byNbrOfChildren)
-	    )
-	     var divider = el("div", [
-	     	el("div.divider-wrapper", [
-		        el("div.queued-divider", [""]),
-		        el("div.divider-title", ["Extend Taxonomy for Collection " + name]),
-		        el("div.queued-divider", [""])
-		    ])
-    	])
-		var modal = el('div#modal.modal', [
-
-			el('div',[
-				divider,
-				el('div.modal-entry-type'),
-				el("div.modal-divider"),
-				cxx,
-				closeButton(),
-				el('div.modal-header-title'),// [`collection #${cID}`]),
-				el("div.modal-divider"),
-				el("div"),
-				saveBtn, cancelButton()
-			])
-		])
-
-		saveBtn.addEventListener("click", function(evt) {
-			taxFunc.save_taxonomy(cID)
-			//To Do - change list to only save new nodes
-        });
-
-	    document.body.appendChild(modal)
-        setTimeout(function(){
-			document.getElementById('modal').classList.add('appear');
-		}, modalAnimation)
-	 }
-
+	
 	/**
 	 * Create a modal that displays contents of an entry & an edit button.
 	 *
@@ -599,9 +525,7 @@ $(document).ready(function() {
             });
 
             document.body.appendChild(modal)
-            setTimeout(function(){
-                document.getElementById('modal').classList.add('appear');
-            }, modalAnimation)
+            modals.appear(modal)
         })
     }
 
@@ -665,9 +589,7 @@ $(document).ready(function() {
 		if (obj.input.length > 0) {
 				inputboxes[0].focus()
 		}
-		setTimeout(function() {
-			document.getElementById('modal').classList.add('appear');
-		}, modalAnimation)
+		modals.appear(modal)
 
 		$("#input0").on("input", function(evt) {
 			var searchString = $(this).val();
@@ -745,9 +667,7 @@ $(document).ready(function() {
 		})
 
         document.body.appendChild(modal)
-		setTimeout(function() {
-			modal.classList.add('appear');
-		}, modalAnimation)
+		modals.appear(modal)
 
         // Focus on first input element
         if (obj.input && obj.input.length) {
@@ -795,34 +715,26 @@ $(document).ready(function() {
         modal.classList.add('confirm')
 	}
 
-		 /* Create simple modal with unique id */
- 	    modals.confirmKickPopUp = function(desc, method) {
- 	      var confirmBtn = el('button#confirm.btn', ['confirm'])
- 	      var modal = el('div#modalConf.modal.confirm', [
- 	              	el('div', [
- 	                closeButton(),
- 	                el("div.modal-header-title", [desc]),
- 	                //name of modal
- 	                el("div#bottom-divider.modal-divider"),
- 	                confirmBtn, cancelButton()
- 	            ])
- 	          ])
+	/* Create simple modal with unique id */
+	modals.confirmKickPopUp = function(desc, method) {
+		var confirmBtn = el('button#confirm.btn', ['confirm'])
+		var modal = el('div#modalConf.modal.confirm', [
+			el('div', [
+				closeButton(),
+				el("div.modal-header-title", [desc]),
+				//name of modal
+				el("div#bottom-divider.modal-divider"),
+				confirmBtn, cancelButton()
+			])
+		])
 
- 	        confirmBtn.addEventListener('click', (evt) => {
- 	            method.apply({modal})
- 	        })
+		confirmBtn.addEventListener('click', (evt) => {
+			method.apply({modal})
+		})
 
- 	      setTimeout(function(){
- 				  document.getElementById('modalConf').classList.add('appear');
- 				  document.getElementById('modalConf').classList.add('confirm');
- 					//document.getElementsByClassName("modal confirm appear").style.zIndex = "1051";
-
-
- 				//	alert($(this).data('id'))
- 	      }, modalAnimation)
-
- 	      document.body.appendChild(modal)
- 		 }
+		modals.appear(modal)
+		document.body.appendChild(modal)
+	}
 
 	modals.clearAll = function() {
 		var modal = document.querySelector('.modal')
@@ -886,33 +798,36 @@ $(document).ready(function() {
 		])
 
 		document.body.appendChild(modal)
-		setTimeout(function() {
-			document.getElementById('modal').classList.add('appear');
-		}, modalAnimation)
+		modals.appear(modal)
 	}
 })
 
 window.addEventListener('load', () => {
 
-	var modalsEvt = window.modalsEvt = {}
-
 	function escapeModal(evt){
 		if (evt.keyCode !== 27)
 			return
-		window.modals.clearAll()
+		
+		/* Notice modal must be clicked to disappear */
+		var noticeModal = document.querySelector('.modal.notice')
+		if (!noticeModal)
+			window.modals.clearAll()
 	}
 
 	function clickOffModal(evt){
 		var remove = evt.target.classList.contains('modal') ||
 					 evt.target.classList.contains('confirm') ||
-					 evt.target.classList.contains('dyn-modal') 
+					 evt.target.classList.contains('dyn-modal')
+
+		/* Notice modal must be clicked to disappear */
+		var isNoticeModal = evt.target.classList.contains('modal') &&
+							evt.target.classList.contains('notice')
+		
+		if (isNoticeModal)
+			return
+
 		if (remove)
 			document.body.removeChild(evt.target)
-	}
-
-	modalsEvt.pardonEvents = function(){
-		document.body.removeEventListener('keydown', escapeModal, false )
-		document.body.removeEventListener('click', clickOffModal, false )
 	}
 
 	// Remove active modals when pressing ESC

--- a/src/js/modal.js
+++ b/src/js/modal.js
@@ -696,6 +696,7 @@ $(document).ready(function() {
      * with modal as context and input values are arguments.
      *
      **/
+
     modals.optionsModal = function(obj, onConfirm, onCancel) {
         var message = [el("div.modal-sub-item", [obj.message])]
 
@@ -776,6 +777,34 @@ $(document).ready(function() {
 
 		document.body.appendChild(modal)
 	}
+
+	//simple modal with text, that user has to click continue to proceed.
+     modals.noticeModal = function(title, desc, method) {
+ 	      var confirmBtn = el('button#continue.btn', ['continue'])
+ 	      var modal = el('div#modalNotice.modal.notice', [
+ 	              	el('div.{overflow-x: visible};', [
+ 	                el("div.modal-header-title", [title]),
+ 	                el("div#bottom-divider.modal-divider"),
+ 	                el("div", [desc]),
+ 	                confirmBtn
+ 	            ])
+ 	          ])
+
+ 	    //removes escape event listeners so user can only press continue to proceed.
+ 	   	var old_el = document.body
+		var new_el= old_el.cloneNode(true);
+		old_el.parentNode.replaceChild(new_el, old_el);
+
+		confirmBtn.addEventListener('click', (evt) => {
+	        method.apply({modal})
+	    })
+
+		setTimeout(function() {
+			modal.classList.add('appear');
+		}, modalAnimation)
+
+ 	      document.body.appendChild(modal)
+ 		}
 
 	/* Create simple modal */
 	modals.confirmPopUp = function(desc, onConfirm) {
@@ -895,7 +924,7 @@ window.addEventListener('load', () => {
 	}, false)
 
 	// Remove active modals when pressing ESC
-	document.addEventListener('keydown', (evt) => {
+	document.body.addEventListener('keydown', (evt) => {
 		if (evt.keyCode !== 27)
 			return
 

--- a/src/js/modal.js
+++ b/src/js/modal.js
@@ -14,6 +14,12 @@ $(document).ready(function() {
 	var modalAnimation = 121
 
 	modals.toggleButtonState = toggleButtonState
+	//slides modal onto screen
+	modals.appear = function(element){
+		setTimeout(function(){
+ 				  element.classList.add('appear');
+ 	      }, modalAnimation)
+	}
 
 	function insertAfter(referenceNode,newNode){
 		referenceNode.parentNode.insertBefore(newNode, referenceNode.nextSibling)
@@ -778,34 +784,6 @@ $(document).ready(function() {
 		document.body.appendChild(modal)
 	}
 
-	//simple modal with text, that user has to click continue to proceed.
-     modals.noticeModal = function(title, desc, method) {
- 	      var confirmBtn = el('button#continue.btn', ['continue'])
- 	      var modal = el('div#modalNotice.modal.notice', [
- 	              	el('div.{overflow-x: visible};', [
- 	                el("div.modal-header-title", [title]),
- 	                el("div#bottom-divider.modal-divider"),
- 	                el("div", [desc]),
- 	                confirmBtn
- 	            ])
- 	          ])
-
- 	    //removes escape event listeners so user can only press continue to proceed.
- 	   	var old_el = document.body
-		var new_el= old_el.cloneNode(true);
-		old_el.parentNode.replaceChild(new_el, old_el);
-
-		confirmBtn.addEventListener('click', (evt) => {
-	        method.apply({modal})
-	    })
-
-		setTimeout(function() {
-			modal.classList.add('appear');
-		}, modalAnimation)
-
- 	      document.body.appendChild(modal)
- 		}
-
 	/* Create simple modal */
 	modals.confirmPopUp = function(desc, onConfirm) {
 		var modal = modals.optionsModal({
@@ -915,19 +893,31 @@ $(document).ready(function() {
 })
 
 window.addEventListener('load', () => {
-	document.body.addEventListener('click', (evt) => {
-		var remove = evt.target.classList.contains('modal') ||
-					 evt.target.classList.contains('confirm') ||
-					 evt.target.classList.contains('dyn-modal')
-		if (remove)
-			document.body.removeChild(evt.target)
-	}, false)
 
-	// Remove active modals when pressing ESC
-	document.body.addEventListener('keydown', (evt) => {
+	var modalsEvt = window.modalsEvt = {}
+
+	function escapeModal(evt){
 		if (evt.keyCode !== 27)
 			return
-
 		window.modals.clearAll()
-	}, false)
+	}
+
+	function clickOffModal(evt){
+		var remove = evt.target.classList.contains('modal') ||
+					 evt.target.classList.contains('confirm') ||
+					 evt.target.classList.contains('dyn-modal') 
+		if (remove)
+			document.body.removeChild(evt.target)
+	}
+
+	modalsEvt.pardonEvents = function(){
+		document.body.removeEventListener('keydown', escapeModal, false )
+		document.body.removeEventListener('click', clickOffModal, false )
+	}
+
+	// Remove active modals when pressing ESC
+	document.body.addEventListener('keydown', escapeModal, false )
+	//Remove active modals when clicking outside modal
+	document.body.addEventListener('click', clickOffModal, false )
+	
 }, false)

--- a/src/js/profile.js
+++ b/src/js/profile.js
@@ -138,7 +138,7 @@ $(function() {
 
     function update(self) {
         userData = self
-
+        
         $(".user-email").text(`${self.email} (${self.trust})`)
 
         $("div.collection-wrapper").remove()

--- a/src/less/workingfiles/mixins.less
+++ b/src/less/workingfiles/mixins.less
@@ -19,7 +19,6 @@
 @table-white: #f9f9f9;
 @red: #F15C4F;
 
-
 // utility functions for less
 .rounded-corners (@radius: 5px) {
     -webkit-border-radius: @radius;

--- a/src/less/workingfiles/modal.less
+++ b/src/less/workingfiles/modal.less
@@ -32,12 +32,10 @@
     margin: 10% auto;
 
     padding: 30px;
-    padding-bottom: 70px;
     background-color: @bg-color;
     border-radius: 2px;
 
     box-shadow: 0 5px 15px rgba(0,0,0,0.5);
-
     overflow-y: scroll;
     overflow-x: hidden;
     opacity:0;
@@ -117,10 +115,16 @@
 }
 
 
-//for smaller confrimation modals
+//for smaller confirmation modals
 .modal.confirm > div{
     max-width: 25%;
-    max-height: 10%;
+    max-height: fit-content;
+}
+
+.modal.notice > div{
+    max-width: 25%;
+    max-height: fit-content;
+    overflow-y: hidden;
 }
 
 .modal.textBox > div{

--- a/src/views/login.jade
+++ b/src/views/login.jade
@@ -1,7 +1,8 @@
 extends base
 block view-specific-scripts
     script(src="js/login.js")
-    script(src="js/modal.js")
+    script(src="js/modal.js")    
+    script(src="js/components/notice-modal.js")
     script(src="js/util/el.js")
 
 block loginlogout

--- a/src/views/login.jade
+++ b/src/views/login.jade
@@ -1,6 +1,8 @@
 extends base
 block view-specific-scripts
     script(src="js/login.js")
+    script(src="js/modal.js")
+    script(src="js/util/el.js")
 
 block loginlogout
     


### PR DESCRIPTION
Notify user about email verification #136

Created a new modal of notice type -
Pops up with some text and disables the standard 'close' event listeners of other modals so that the user has to click the respective button to show they've read the message. 
Did this by cloning the body node so that the original event listeners are removed.

Also a quick fix to the max height of the modals - the 'delete account' modal on the profile page was looking out of sorts so this seemed like a simple fix - tried on mozilla & chrome. 